### PR TITLE
WIP: add more uuid_ functions

### DIFF
--- a/common/c_cpp/src/c/cmake/darwin-files.cmake
+++ b/common/c_cpp/src/c/cmake/darwin-files.cmake
@@ -6,4 +6,5 @@ set(SYSTEM_SOURCES
         darwin/wSemaphore.c
         darwin/port.c
         darwin/clock.c
+        darwin/wUuid.c
 )

--- a/common/c_cpp/src/c/darwin/wUuid.c
+++ b/common/c_cpp/src/c/darwin/wUuid.c
@@ -19,20 +19,11 @@
  * 02110-1301 USA
  */
 
+#include <wombat/wUuid.h>
 
-#ifndef WUUID_H__
-#define WUUID_H__
-
-#include <uuid/uuid.h>
-
-typedef uuid_t wUuid;
-
-#define wUuid_generate              uuid_generate
-#define wUuid_generate_time         uuid_generate_time
-#define wUuid_generate_random       uuid_generate_random
-
-#define wUuid_unparse uuid_unparse
-
-#define wUuid_clear(UUID) uuid_clear(UUID)
-
-#endif /* WUUID_H__ */
+int wUuid_generate_time_safe (wUuid myUuid)
+{
+   uuid_generate_time(myUuid);
+   /* since we cant guarantee that the uuid was generated in a safe manner, return -1 */
+   return -1;
+}

--- a/common/c_cpp/src/c/darwin/wombat/wUuid.h
+++ b/common/c_cpp/src/c/darwin/wombat/wUuid.h
@@ -29,6 +29,7 @@ typedef uuid_t wUuid;
 
 #define wUuid_generate              uuid_generate
 #define wUuid_generate_time         uuid_generate_time
+int wUuid_generate_time_safe (wUuid myUuid);
 #define wUuid_generate_random       uuid_generate_random
 
 #define wUuid_unparse uuid_unparse

--- a/common/c_cpp/src/c/linux/wombat/wUuid.h
+++ b/common/c_cpp/src/c/linux/wombat/wUuid.h
@@ -27,10 +27,13 @@
 
 typedef uuid_t wUuid;
 
-#define wUuid_generate_time uuid_generate_time
+#define wUuid_generate              uuid_generate
+#define wUuid_generate_time         uuid_generate_time
+#define wUuid_generate_time_safe    uuid_generate_time_safe
+#define wUuid_generate_random       uuid_generate_random
 
 #define wUuid_unparse uuid_unparse
 
-#define wUuid_clear(UUID) uuid_clear(UUID);
+#define wUuid_clear(UUID) uuid_clear(UUID)
 
 #endif /* WUUID_H__ */


### PR DESCRIPTION
# add more uuid_ functions
## Summary
Some applications could use addl. uuid_ functions

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
Add more uuid_ functions -- in particular uuid_generate_times_safe which is useful for applications that must guarantee that uuid's are in fact unique.

## Testing
Tested in separate application that uses OpenMAMA API.
