### PR TITLE
Disable centos stream upload for cloudsmith

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
         path: ${{ env.PKG }}
     - name: Upload package to cloudsmith
       uses: cloudsmith-io/action@master
-      if: ${{ env.ARTIFACT_TYPE }}
+      if: ${{ env.ARTIFACT_TYPE && matrix.distro_version != "stream" }}
       env:
         artifact_type: ${{ env.ARTIFACT_TYPE }}
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
         path: ${{ env.PKG }}
     - name: Upload package to cloudsmith
       uses: cloudsmith-io/action@master
-      if: ${{ env.ARTIFACT_TYPE && matrix.distro_version != "stream" }}
+      if: ${{ env.ARTIFACT_TYPE && matrix.distro_version != 'stream' }}
       env:
         artifact_type: ${{ env.ARTIFACT_TYPE }}
       with:


### PR DESCRIPTION
Cloudsmith does not yet have centos stream separated from el/8.

Signed-off-by: Frank Quinn <fquinn@cascadium.io>