### PR TITLE
- fix buffer overrun

### DIFF
--- a/mama/c_cpp/src/c/datetime.c
+++ b/mama/c_cpp/src/c/datetime.c
@@ -302,7 +302,7 @@ mamaDateTime_setWithHints(mamaDateTime           dateTime,
 
     if (microseconds >= 1000000)
         return MAMA_STATUS_INVALID_ARG;
-    
+
     mamaDateTimeImpl_clear           ((mama_datetime_t*)dateTime);
     mamaDateTimeImpl_setSeconds      ((mama_datetime_t*)dateTime, seconds);
     mamaDateTimeImpl_setMicroSeconds ((mama_datetime_t*)dateTime, microseconds);
@@ -483,7 +483,7 @@ mamaDateTime_setFromStringBufferWithTz(mamaDateTime       dateTime,
                                        const mamaTimeZone tz)
 {
     mama_status status;
-    char* tmpStr = (char*) malloc (strLen +1);
+    char* tmpStr = (char*) calloc (strLen +1, 1);
     if (!tmpStr)
         return MAMA_STATUS_NOMEM;
 
@@ -594,7 +594,7 @@ mamaDateTime_setTimeWithPrecisionAndTz(mamaDateTime           dateTime,
 
     if (microsecond >= 1000000)
         return MAMA_STATUS_INVALID_ARG;
-    
+
     /* Get existing number of seconds and remove any intraday-seconds. */
     tmpSeconds = (mamaDateTimeImpl_getSeconds ((mama_datetime_t*)dateTime) / SECONDS_IN_A_DAY) *
                                                   SECONDS_IN_A_DAY;


### PR DESCRIPTION
# fix buffer overrun
## Summary
AddressSanitizer detects a buffer overrun in date/time tests.

## Areas Affected
*Place an 'x' within the braces to check the box*
- [x] MAMAC
- [ ] MAMACPP
- [ ] MAMADOTNET
- [ ] MAMAJNI
- [ ] MAMDA
- [ ] MAMDACPP
- [ ] MAMDADOTNET
- [ ] MAMDAJNI
- [ ] Visual Studio
- [ ] SCons
- [ ] Unit Tests
- [ ] Examples

## Details
```
=================================================================
==878864==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200000ec72 at pc 0x0000004c3414 bp 0x7ffc26f6c250 sp 0x7ffc26f6ba10
READ of size 3 at 0x60200000ec72 thread T0
    #0 0x4c3413 in strchr (/home/btorpey/install/OpenMAMA/master/asan/bin/UnitTestMamaDateTimeC+0x4c3413)
    #1 0x7fbde16d1c36 in mamaDateTime_setFromStringWithTz /home/btorpey/work/OpenMAMA/master/src/mama/c_cpp/src/c/datetime.c:375:31
    #2 0x7fbde16d24af in mamaDateTime_setFromStringBufferWithTz /home/btorpey/work/OpenMAMA/master/src/mama/c_cpp/src/c/datetime.c:491:14
    #3 0x7fbde16d24af in mamaDateTime_setFromStringBuffer /home/btorpey/work/OpenMAMA/master/src/mama/c_cpp/src/c/datetime.c:476:12
    #4 0x5cb9a6 in MamaDateTimeTestC_TestSetFromStringBuffer_Test::TestBody() /home/btorpey/work/OpenMAMA/master/src/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp:715:5
    #5 0x696ddc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2402
    #6 0x691651 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2438
    #7 0x676d69 in testing::Test::Run() /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2475
    #8 0x6775d9 in testing::TestInfo::Run() /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2656
    #9 0x677c13 in testing::TestCase::Run() /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2774
    #10 0x67e736 in testing::internal::UnitTestImpl::RunAllTests() /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:4649
    #11 0x697c62 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2402
    #12 0x69236b in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2438
    #13 0x67d43b in testing::UnitTest::Run() /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:4257
    #14 0x66faee in RUN_ALL_TESTS() /build/share/googletest/1.8.0-gcc530/include/gtest/gtest.h:2233:46
    #15 0x66faee in main /home/btorpey/work/OpenMAMA/master/src/mama/c_cpp/src/gunittest/c/MainUnitTestC.cpp:181:12
    #16 0x7fbde103c0b2 in __libc_start_main /build/glibc-eX1tMB/glibc-2.31/csu/../csu/libc-start.c:308:16
    #17 0x4adc4d in _start (/home/btorpey/install/OpenMAMA/master/asan/bin/UnitTestMamaDateTimeC+0x4adc4d)

0x60200000ec72 is located 0 bytes to the right of 2-byte region [0x60200000ec70,0x60200000ec72)
allocated by thread T0 here:
    #0 0x52638d in malloc (/home/btorpey/install/OpenMAMA/master/asan/bin/UnitTestMamaDateTimeC+0x52638d)
    #1 0x7fbde16d248c in mamaDateTime_setFromStringBufferWithTz /home/btorpey/work/OpenMAMA/master/src/mama/c_cpp/src/c/datetime.c:486:28
    #2 0x7fbde16d248c in mamaDateTime_setFromStringBuffer /home/btorpey/work/OpenMAMA/master/src/mama/c_cpp/src/c/datetime.c:476:12
    #3 0x5cb9a6 in MamaDateTimeTestC_TestSetFromStringBuffer_Test::TestBody() /home/btorpey/work/OpenMAMA/master/src/mama/c_cpp/src/gunittest/c/mamadatetime/datetimetest.cpp:715:5
    #4 0x696ddc in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2402
    #5 0x691651 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2438
    #6 0x676d69 in testing::Test::Run() /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2475
    #7 0x6775d9 in testing::TestInfo::Run() /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2656
    #8 0x677c13 in testing::TestCase::Run() /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2774
    #9 0x67e736 in testing::internal::UnitTestImpl::RunAllTests() /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:4649
    #10 0x697c62 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2402
    #11 0x69236b in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:2438
    #12 0x67d43b in testing::UnitTest::Run() /shared/buildtest/googletest/1.8.0-gcc530/googletest-release-1.8.0/googletest/src/gtest.cc:4257
    #13 0x66faee in RUN_ALL_TESTS() /build/share/googletest/1.8.0-gcc530/include/gtest/gtest.h:2233:46
    #14 0x66faee in main /home/btorpey/work/OpenMAMA/master/src/mama/c_cpp/src/gunittest/c/MainUnitTestC.cpp:181:12
    #15 0x7fbde103c0b2 in __libc_start_main /build/glibc-eX1tMB/glibc-2.31/csu/../csu/libc-start.c:308:16

SUMMARY: AddressSanitizer: heap-buffer-overflow (/home/btorpey/install/OpenMAMA/master/asan/bin/UnitTestMamaDateTimeC+0x4c3413) in strchr
Shadow bytes around the buggy address:
  0x0c047fff9d30: fa fa 00 05 fa fa 00 01 fa fa 00 03 fa fa 00 01
  0x0c047fff9d40: fa fa 00 03 fa fa 00 03 fa fa 00 04 fa fa 00 02
  0x0c047fff9d50: fa fa 00 05 fa fa 00 00 fa fa 00 07 fa fa 00 05
  0x0c047fff9d60: fa fa 00 01 fa fa 00 07 fa fa 00 05 fa fa 00 00
  0x0c047fff9d70: fa fa 05 fa fa fa 06 fa fa fa 00 fa fa fa fd fa
=>0x0c047fff9d80: fa fa 00 03 fa fa 00 fa fa fa 00 fa fa fa[02]fa
  0x0c047fff9d90: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff9da0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff9db0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff9dc0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff9dd0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==878864==ABORTING
```

The original code allocates a buffer of strlen()+1, but since strncpy does not null-terminate the string, subsequent comparisons can (and often do) run past the length of the buffer.  Changing the buffer allocation from `malloc` to `calloc` guarantees the the string is null-terminated.

## Testing
Subsequent test runs pass and do not trigger the ASAN error.