### PR TITLE
Added new OpenMAMA Playback Bridge (ompb)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set (WITH_UNITTEST      false  CACHE BOOL   "Include unit tests in the build (e.
 set (WITH_PROTON        true   CACHE BOOL   "Include the qpid proton middleware and payload bridges in the build")
 set (WITH_NOOP_BRIDGE   false  CACHE BOOL   "Include the noop example middleware bridge in the build")
 set (WITH_BASE_BRIDGE   true   CACHE BOOL   "Include the base bridge in the build (required for qpid proton)")
+set (WITH_OMPB_BRIDGE   true   CACHE BOOL   "Include the OpenMAMA Playback bridge in the build (subscriber only)")
 set (WITH_MAMDA         true   CACHE BOOL   "Include MAMDA in the build")
 set (WITH_CPP           true   CACHE BOOL   "Include C++ bindings")
 set (WITH_CSHARP        false  CACHE BOOL   "Include C# bindings")

--- a/mama/CMakeLists.txt
+++ b/mama/CMakeLists.txt
@@ -74,6 +74,10 @@ if (WITH_NOOP_BRIDGE)
     add_subdirectory (c_cpp/src/c/bridge/noop)
 endif ()
 
+if (WITH_OMPB_BRIDGE)
+    add_subdirectory (c_cpp/src/c/bridge/ompb)
+endif ()
+
 if (WITH_PROTON)
     add_subdirectory (c_cpp/src/c/bridge/qpid)
     add_subdirectory (c_cpp/src/c/payload/qpidmsg)

--- a/mama/c_cpp/src/c/bridge/noop/transport.c
+++ b/mama/c_cpp/src/c/bridge/noop/transport.c
@@ -28,6 +28,7 @@ mama_status
 noopBridgeMamaTransport_destroy (transportBridge transport)
 {
     free (transport);
+    return MAMA_STATUS_OK;
 }
 
 mama_status

--- a/mama/c_cpp/src/c/bridge/ompb/CMakeLists.txt
+++ b/mama/c_cpp/src/c/bridge/ompb/CMakeLists.txt
@@ -1,0 +1,41 @@
+string(TOLOWER ${CMAKE_SYSTEM_NAME} system)
+
+set(BRIDGE_STUB_NAME ompb)
+
+include_directories(.)
+include_directories(../..)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/../../)
+include_directories(../../../../../../common/c_cpp/src/c/${system})
+include_directories(../../../../../../common/c_cpp/src/c)
+
+add_definitions(-DBRIDGE -DBRIDGE_STUB_NAME=${BRIDGE_STUB_NAME})
+
+add_library(mama${BRIDGE_STUB_NAME}impl SHARED
+        bridgefunctions.h
+        bridge.c
+        publisher.c
+        subscription.c
+        transport.c
+        transport.h
+)
+
+if(WIN32)
+    target_link_libraries(mama${BRIDGE_STUB_NAME}impl
+                          wombatcommon
+                          mama)
+
+    # Windows Targets
+    set_target_properties(mama${BRIDGE_STUB_NAME}impl PROPERTIES OUTPUT_NAME "mama${BRIDGE_STUB_NAME}impl${OPENMAMA_LIBRARY_SUFFIX}")
+    if (MSVC)
+        install(FILES $<TARGET_PDB_FILE:mama${BRIDGE_STUB_NAME}impl> DESTINATION bin OPTIONAL)
+    endif()
+    install(TARGETS mama${BRIDGE_STUB_NAME}impl
+            RUNTIME DESTINATION bin
+            LIBRARY DESTINATION bin
+            ARCHIVE DESTINATION lib)
+elseif(UNIX)
+    target_link_libraries(mama${BRIDGE_STUB_NAME}impl
+                          wombatcommon
+                          mama)
+    install(TARGETS mama${BRIDGE_STUB_NAME}impl DESTINATION lib)
+endif()

--- a/mama/c_cpp/src/c/bridge/ompb/bridge.c
+++ b/mama/c_cpp/src/c/bridge/ompb/bridge.c
@@ -1,0 +1,110 @@
+/*=========================================================================
+  =                             Includes                                  =
+  =========================================================================*/
+
+#include <mama/mama.h>
+#include <mama/version.h>
+#include <timers.h>
+#include <wombat/strutils.h>
+#include <mama/integration/mama.h>
+#include "bridgefunctions.h"
+
+
+/*=========================================================================
+  =                Typedefs, structs, enums and globals                   =
+  =========================================================================*/
+
+/* Version identifiers */
+#define             BRIDGE_NAME            "ompb"
+#define             BRIDGE_VERSION         "1.0"
+
+/* Default payload names and IDs to be loaded when this bridge is loaded */
+static char*        PAYLOAD_NAMES[]         =   { "qpidmsg", NULL };
+static char         PAYLOAD_IDS[]           =   { MAMA_PAYLOAD_QPID, '\0' };
+
+
+/*=========================================================================
+  =                              Macros                                   =
+  =========================================================================*/
+
+
+/*=========================================================================
+  =               Public interface implementation functions               =
+  =========================================================================*/
+
+/* Must be immplemented in overriding bridge */
+mama_status
+ompbBridge_init (mamaBridge bridgeImpl)
+{
+    mama_status status         = MAMA_STATUS_OK;
+    const char* runtimeVersion = NULL;
+
+    /* Reusable buffer to populate with property values */
+    char propString[MAX_INTERNAL_PROP_LEN];
+    versionInfo rtVer;
+
+    mama_log (MAMA_LOG_LEVEL_SEVERE, "ompbBridge_init(): IN INIT");
+
+    /* Will set the bridge's compile time MAMA version */
+    MAMA_SET_BRIDGE_COMPILE_TIME_VERSION(BRIDGE_NAME);
+
+    /* Enable extending of the base bridge implementation */
+    status = mamaBridgeImpl_setReadOnlyProperty (bridgeImpl,
+                                                 MAMA_PROP_EXTENDS_BASE_BRIDGE,
+                                                 "true");
+
+    /* Get the runtime version of MAMA and parse into version struct */
+    runtimeVersion = mamaInternal_getMetaProperty (MAMA_PROP_MAMA_RUNTIME_VER);
+    strToVersionInfo (runtimeVersion, &rtVer);
+
+    /* NB checks are runtime only - assume build system will prevent accidental
+     * compilation against incompatible versions. This is a demonstration to
+     * show how you could do runtime version checking. */
+    if (1 == rtVer.mMajor)
+    {
+        mama_log (MAMA_LOG_LEVEL_SEVERE, "ompbBridge_init(): "
+                                         "This version of the bridge (%s) cannot be used with MAMA %s.",
+                  BRIDGE_VERSION,
+                  runtimeVersion);
+        return MAMA_STATUS_NOT_IMPLEMENTED;
+    }
+
+    return status;
+}
+
+/* Must be immplemented in overriding bridge */
+const char*
+ompbBridge_getVersion (void)
+{
+    return BRIDGE_VERSION;
+}
+
+/* Must be immplemented in overriding bridge */
+const char*
+ompbBridge_getName (void)
+{
+    return BRIDGE_NAME;
+}
+
+/* Must be immplemented in overriding bridge */
+mama_status
+ompbBridge_getDefaultPayloadId (char ***name, char **id)
+{
+    if (NULL == name || NULL == id)
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
+    /*
+     * Populate name with the value of all supported payload names, the first
+     * being the default
+     */
+    *name   = PAYLOAD_NAMES;
+
+    /*
+     * Populate id with the char keys for all supported payload names, the first
+     * being the default
+     */
+    *id     = PAYLOAD_IDS;
+
+    return MAMA_STATUS_OK;
+}

--- a/mama/c_cpp/src/c/bridge/ompb/bridgefunctions.h
+++ b/mama/c_cpp/src/c/bridge/ompb/bridgefunctions.h
@@ -6,23 +6,23 @@
 
 MAMAExpBridgeDLL
 mama_status
-noopBridge_init (mamaBridge bridgeImpl);
+ompbBridge_init (mamaBridge bridgeImpl);
 
 MAMAExpBridgeDLL
 const char*
-noopBridge_getVersion (void);
+ompbBridge_getVersion (void);
 
 MAMAExpBridgeDLL
 const char*
-noopBridge_getName (void);
+ompbBridge_getName (void);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridge_getDefaultPayloadId (char ***name, char **id);
+ompbBridge_getDefaultPayloadId (char ***name, char **id);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaPublisher_createByIndex (publisherBridge*     result,
+ompbBridgeMamaPublisher_createByIndex (publisherBridge*     result,
                                            mamaTransport        tport,
                                            int                  tportIndex,
                                            const char*          topic,
@@ -32,47 +32,47 @@ noopBridgeMamaPublisher_createByIndex (publisherBridge*     result,
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaPublisher_destroy (publisherBridge publisher);
+ompbBridgeMamaPublisher_destroy (publisherBridge publisher);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaPublisher_send (publisherBridge publisher, mamaMsg msg);
+ompbBridgeMamaPublisher_send (publisherBridge publisher, mamaMsg msg);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaPublisher_sendReplyToInbox (publisherBridge   publisher,
+ompbBridgeMamaPublisher_sendReplyToInbox (publisherBridge   publisher,
                                               mamaMsg           request,
                                               mamaMsg           reply);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaPublisher_sendReplyToInboxHandle (publisherBridge     publisher,
+ompbBridgeMamaPublisher_sendReplyToInboxHandle (publisherBridge     publisher,
                                                     void*               inbox,
                                                     mamaMsg             reply);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaPublisher_sendFromInboxByIndex (publisherBridge   publisher,
+ompbBridgeMamaPublisher_sendFromInboxByIndex (publisherBridge   publisher,
                                                   int               tportIndex,
                                                   mamaInbox         inbox,
                                                   mamaMsg           msg);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaPublisher_sendFromInbox (publisherBridge  publisher,
+ompbBridgeMamaPublisher_sendFromInbox (publisherBridge  publisher,
                                            mamaInbox        inbox,
                                            mamaMsg          msg);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaPublisher_setUserCallbacks (publisherBridge         publisher,
+ompbBridgeMamaPublisher_setUserCallbacks (publisherBridge         publisher,
                                               mamaQueue               queue,
                                               mamaPublisherCallbacks* cb,
                                               void*                   closure);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaSubscription_create (subscriptionBridge* subscriber,
+ompbBridgeMamaSubscription_create (subscriptionBridge* subscriber,
                                        const char*         source,
                                        const char*         symbol,
                                        mamaTransport       tport,
@@ -83,38 +83,38 @@ noopBridgeMamaSubscription_create (subscriptionBridge* subscriber,
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaSubscription_mute (subscriptionBridge subscriber);
+ompbBridgeMamaSubscription_mute (subscriptionBridge subscriber);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaSubscription_destroy (subscriptionBridge subscriber);
+ompbBridgeMamaSubscription_destroy (subscriptionBridge subscriber);
 
 MAMAExpBridgeDLL
 int
-noopBridgeMamaSubscription_isValid (subscriptionBridge subscriber);
+ompbBridgeMamaSubscription_isValid (subscriptionBridge subscriber);
 
 MAMAExpBridgeDLL
 int
-noopBridgeMamaSubscription_hasWildcards (subscriptionBridge subscriber);
+ompbBridgeMamaSubscription_hasWildcards (subscriptionBridge subscriber);
 
 MAMAExpBridgeDLL
 int
-noopBridgeMamaSubscription_isTportDisconnected (subscriptionBridge subscriber);
+ompbBridgeMamaSubscription_isTportDisconnected (subscriptionBridge subscriber);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaSubscription_muteCurrentTopic (subscriptionBridge subscriber);
+ompbBridgeMamaSubscription_muteCurrentTopic (subscriptionBridge subscriber);
 
 MAMAExpBridgeDLL
 int
-noopBridgeMamaTransport_isValid (transportBridge transport);
+ompbBridgeMamaTransport_isValid (transportBridge transport);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaTransport_destroy (transportBridge transport);
+ompbBridgeMamaTransport_destroy (transportBridge transport);
 
 MAMAExpBridgeDLL
 mama_status
-noopBridgeMamaTransport_create (transportBridge*    result,
+ompbBridgeMamaTransport_create (transportBridge*    result,
                                     const char*         name,
                                     mamaTransport       parent);

--- a/mama/c_cpp/src/c/bridge/ompb/publisher.c
+++ b/mama/c_cpp/src/c/bridge/ompb/publisher.c
@@ -1,0 +1,162 @@
+/*=========================================================================
+ =                             Includes                                  =
+ =========================================================================*/
+
+#include <stdint.h>
+#include <string.h>
+
+#include "bridgefunctions.h"
+#include <mama/mama.h>
+#include <mama/inbox.h>
+#include <mama/publisher.h>
+#include <mama/integration/bridge.h>
+#include <mama/integration/publisher.h>
+
+typedef struct implPublisherBridge
+{
+    transportBridge         mTransport;
+    const char*             mTopic;
+    const char*             mSource;
+    const char*             mRoot;
+    msgBridge               mMamaBridgeMsg;
+    mamaPublisher           mParent;
+    mamaPublisherCallbacks  mCallbacks;
+    void*                   mCallbackClosure;
+} implPublisherBridge;
+
+/*=========================================================================
+ =               Public interface implementation functions               =
+ =========================================================================*/
+
+mama_status
+ompbBridgeMamaPublisher_createByIndex (publisherBridge*     result,
+                                       mamaTransport        tport,
+                                       int                  tportIndex,
+                                       const char*          topic,
+                                       const char*          source,
+                                       const char*          root,
+                                       mamaPublisher        parent)
+{
+    implPublisherBridge* impl = (implPublisherBridge*) calloc (1, sizeof(implPublisherBridge));
+
+    if (NULL == impl)
+    {
+        return MAMA_STATUS_NOMEM;
+    }
+
+    mamaTransport_getBridgeTransport (tport, &impl->mTransport);
+
+    if (NULL != source)
+    {
+        impl->mSource = strdup(source);
+    }
+
+    if (NULL != topic)
+    {
+        impl->mTopic = strdup(topic);
+    }
+
+    if (NULL != root)
+    {
+        impl->mRoot = strdup(root);
+    }
+
+    impl->mParent = parent;
+
+    *result = (publisherBridge)impl;
+
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+ompbBridgeMamaPublisher_destroy (publisherBridge publisher)
+{
+    mamaPublisherCallbacks  callbacks;
+    mamaPublisher           parent  = NULL;
+    void*                   closure = NULL;
+    implPublisherBridge*    impl    = (implPublisherBridge*) publisher;
+
+    if (NULL == impl)
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
+
+    free ((void*)impl->mRoot);
+    free ((void*)impl->mSource);
+    free ((void*)impl->mTopic);
+
+    /* Take a copy of the callbacks - we'll need those */
+    callbacks = impl->mCallbacks;
+    parent    = impl->mParent;
+    closure   = impl->mCallbackClosure;
+
+    if (NULL != callbacks.onDestroy)
+    {
+        (*callbacks.onDestroy)(parent, closure);
+    }
+
+    free (impl);
+
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+ompbBridgeMamaPublisher_send (publisherBridge publisher, mamaMsg msg)
+{
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+ompbBridgeMamaPublisher_sendReplyToInbox (publisherBridge   publisher,
+                                          mamaMsg           request,
+                                          mamaMsg           reply)
+{
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+ompbBridgeMamaPublisher_sendReplyToInboxHandle (publisherBridge     publisher,
+                                                void*               inbox,
+                                                mamaMsg             reply)
+{
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+ompbBridgeMamaPublisher_sendFromInboxByIndex (publisherBridge   publisher,
+                                              int               tportIndex,
+                                              mamaInbox         inbox,
+                                              mamaMsg           msg)
+{
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+ompbBridgeMamaPublisher_sendFromInbox (publisherBridge  publisher,
+                                       mamaInbox        inbox,
+                                       mamaMsg          msg)
+{
+    return ompbBridgeMamaPublisher_sendFromInboxByIndex (publisher,
+                                                             0,
+                                                             inbox,
+                                                             msg);
+}
+
+mama_status
+ompbBridgeMamaPublisher_setUserCallbacks (publisherBridge         publisher,
+                                          mamaQueue               queue,
+                                          mamaPublisherCallbacks* cb,
+                                          void*                   closure)
+{
+    implPublisherBridge* impl = (implPublisherBridge*) publisher;
+
+    if (NULL == impl || NULL == cb)
+    {
+        return MAMA_STATUS_NULL_ARG;
+    }
+    /* Take a copy of the callbacks */
+    impl->mCallbacks = *cb;
+    impl->mCallbackClosure = closure;
+
+    return MAMA_STATUS_OK;
+}

--- a/mama/c_cpp/src/c/bridge/ompb/subscription.c
+++ b/mama/c_cpp/src/c/bridge/ompb/subscription.c
@@ -1,0 +1,119 @@
+/*=========================================================================
+  =                             Includes                                  =
+  =========================================================================*/
+
+#include <stdint.h>
+#include "bridgefunctions.h"
+#include "transport.h"
+#include <mama/mama.h>
+#include <property.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct implSubscriptionBridge_
+{
+    mamaMsgCallbacks    mMamaCallback;
+    mamaSubscription    mMamaSubscription;
+    mamaQueue           mMamaQueue;
+    transportBridge     mTransport;
+    const char*         mSource;
+    const char*         mSymbol;
+    void*               mClosure;
+} implSubscriptionBridge;
+
+/*=========================================================================
+  =               Public interface implementation functions               =
+  =========================================================================*/
+
+mama_status
+ompbBridgeMamaSubscription_create (subscriptionBridge* subscriber,
+                                   const char*         source,
+                                   const char*         symbol,
+                                   mamaTransport       tport,
+                                   mamaQueue           queue,
+                                   mamaMsgCallbacks    callback,
+                                   mamaSubscription    subscription,
+                                   void*               closure)
+{
+    implSubscriptionBridge* impl = (implSubscriptionBridge*) calloc (1, sizeof(implSubscriptionBridge));
+
+    if (NULL == impl)
+    {
+        return MAMA_STATUS_NOMEM;
+    }
+
+    mamaTransport_getBridgeTransport (tport, &impl->mTransport);
+
+    if (NULL != source)
+    {
+        impl->mSource = strdup(source);
+    }
+
+    if (NULL != symbol)
+    {
+        impl->mSymbol = strdup(symbol);
+    }
+
+    impl->mMamaCallback        = callback;
+    impl->mMamaSubscription    = subscription;
+    impl->mMamaQueue           = queue;
+
+    if (source != NULL && symbol != NULL)
+    {
+        char identifier[PROPERTY_NAME_MAX_LENGTH];
+        snprintf(identifier, sizeof(identifier), "%s.%s", source, symbol);
+        ompbBridgeMamaTransportImpl_registerSubscription (
+            impl->mTransport, identifier, subscription);
+    } else if (source != NULL) {
+        ompbBridgeMamaTransportImpl_registerSubscription (
+            impl->mTransport, source, subscription);
+    } else if (symbol != NULL) {
+        ompbBridgeMamaTransportImpl_registerSubscription (
+            impl->mTransport, symbol, subscription);
+    }
+
+    *subscriber = (subscriptionBridge)impl;
+
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+ompbBridgeMamaSubscription_mute (subscriptionBridge subscriber)
+{
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+ompbBridgeMamaSubscription_destroy (subscriptionBridge subscriber)
+{
+    implSubscriptionBridge* impl = (implSubscriptionBridge*) subscriber;
+    free ((void*)impl->mSource);
+    free ((void*)impl->mSymbol);
+    free (subscriber);
+    return MAMA_STATUS_OK;
+}
+
+int
+ompbBridgeMamaSubscription_isValid (subscriptionBridge subscriber)
+{
+    return 1;
+}
+
+int
+ompbBridgeMamaSubscription_hasWildcards (subscriptionBridge subscriber)
+{
+    return 0;
+}
+
+int
+ompbBridgeMamaSubscription_isTportDisconnected (subscriptionBridge subscriber)
+{
+    return MAMA_STATUS_OK;
+}
+
+mama_status
+ompbBridgeMamaSubscription_muteCurrentTopic (subscriptionBridge subscriber)
+{
+    return ompbBridgeMamaSubscription_mute (subscriber);
+}
+

--- a/mama/c_cpp/src/c/bridge/ompb/transport.c
+++ b/mama/c_cpp/src/c/bridge/ompb/transport.c
@@ -1,0 +1,290 @@
+/*=========================================================================
+  =                             Includes                                  =
+  =========================================================================*/
+
+#include "transport.h"
+#include "bridgefunctions.h"
+#include <mama/integration/mama.h>
+#include <mama/integration/transport.h>
+#include <mama/mama.h>
+#include <playback/playbackFileParser.h>
+#include <signal.h>
+#include <wombat/mempool.h>
+
+#define DEFAULT_PLAYBACK_RATE 1000
+
+typedef struct implTransportBridge_
+{
+    mama_bool_t             mIsValid;
+    mama_bool_t             mRewindEnabled;
+    mama_bool_t             mRaiseEnabled;
+    mamaTransport           mTransport;
+    const char*             mName;
+    mamaQueue               mDispatcherQueue;
+    mamaDispatcher          mDispatcher;
+    mamaTimer               mDispatcherTimer;
+    const char*             mFileName;
+    mama_f64_t              mPlaybackInterval;
+    mamaPlaybackFileParser  mFileParser;
+    wtable_t                mSubscriptions;
+    wthread_mutex_t         mSubscriptionsLock;
+} implTransportBridge;
+
+/*=========================================================================
+  =               Public interface implementation functions               =
+  =========================================================================*/
+
+int
+ompbBridgeMamaTransport_isValid (transportBridge transport)
+{
+    return ((implTransportBridge*)transport)->mIsValid;
+}
+
+mama_status
+ompbBridgeMamaTransport_destroy (transportBridge transport)
+{
+    printf("DESTROYING THE TRANSPORT IF THIS WORKS...\n");
+    free (transport);
+    return MAMA_STATUS_OK;
+}
+
+void ompbBridgeMamaTransportImpl_registerSubscription(transportBridge transport,
+                                                      const char* identifier,
+                                                      mamaSubscription sub)
+{
+    mama_log(MAMA_LOG_LEVEL_NORMAL, "Registering subscription for [%s]", identifier);
+    implTransportBridge* impl = (implTransportBridge*) transport;
+    wthread_mutex_lock (&impl->mSubscriptionsLock);
+    if (WTABLE_INSERT_SUCCESS != wtable_insert (
+             impl->mSubscriptions, identifier, sub)) {
+        mama_log(MAMA_LOG_LEVEL_ERROR,
+                  "Failed to register subscription %s",
+                  identifier);
+    }
+    wthread_mutex_unlock (&impl->mSubscriptionsLock);
+}
+
+#define HEADER_DELIM ':'
+
+void ompbBridgeMamaTransportImpl_dispatchThread (mamaTimer timer, void* closure)
+{
+    implTransportBridge* impl = (implTransportBridge*) closure;
+
+    // Read on if further header is available
+    char* headerString;
+    mamaMsg msg;
+
+    int         index        = 0;
+    char*       sourceStart  = NULL;
+    char*       tportStart   = NULL;
+    char*       symStart     = NULL;
+    char*       lenStart     = NULL;
+    char*       next       = NULL;
+
+    if (mamaPlaybackFileParser_getNextHeader (impl->mFileParser, &headerString))
+    {
+        // Read on if further message is available
+        sourceStart = headerString;
+        tportStart = strchr (sourceStart, HEADER_DELIM);
+        *tportStart = '\0';
+        symStart = strchr (++tportStart, HEADER_DELIM);
+        *symStart = '\0';
+        lenStart = strchr (++symStart, HEADER_DELIM);
+        *lenStart = '\0';
+
+        char identifier[PROPERTY_NAME_MAX_LENGTH];
+        snprintf(identifier, sizeof(identifier), "%s.%s", sourceStart, symStart);
+
+        if (mamaPlaybackFileParser_getNextMsg (impl->mFileParser, &msg)) {
+            /*
+             * Should have a message here which can be relayed onto whatever
+             * subscriptions are hanging off this transport
+             */
+            wthread_mutex_lock (&impl->mSubscriptionsLock);
+            void* element = wtable_lookup (impl->mSubscriptions, identifier);
+            wthread_mutex_unlock (&impl->mSubscriptionsLock);
+            if (element != NULL) {
+                mamaSubscription subscription = (mamaSubscription)element;
+                // Process inline since the msg is transient
+                mamaSubscription_processMsg (subscription, msg);
+            }
+        } else {
+            mama_log(MAMA_LOG_LEVEL_WARN,
+                      "Found a header '%s' but no body in playback file.",
+                      headerString);
+        }
+    }
+    else if (impl->mRewindEnabled)
+    {
+        mama_log(MAMA_LOG_LEVEL_NORMAL,
+                  "Could not get next header - attempting rewind.");
+        mama_status status = mamaPlaybackFileParser_rewindFile (impl->mFileParser);
+        if (status != MAMA_STATUS_OK) {
+            mama_log(MAMA_LOG_LEVEL_ERROR,
+                      "Failed to rewind playback file");
+        }
+    }
+    else if (impl->mRaiseEnabled) {
+        raise(2);
+    }
+}
+
+mama_status
+ompbBridgeMamaTransport_create (transportBridge*    result,
+                                const char*         name,
+                                mamaTransport       parent)
+{
+    *result = (transportBridge) calloc (1, sizeof(implTransportBridge));
+    if (NULL == *result || NULL == name)
+    {
+        return MAMA_STATUS_NOMEM;
+    }
+    implTransportBridge* impl = (implTransportBridge*) *result;
+    mamaBridge bridge = mamaTransportImpl_getBridgeImpl (parent);
+    if (NULL == bridge) {
+        goto cleanup_error;
+    }
+    mama_status status = mamaQueue_create(&impl->mDispatcherQueue, bridge);
+    if (status != MAMA_STATUS_OK) {
+        mama_log(MAMA_LOG_LEVEL_ERROR,
+                  "Failed to create transport queue for %s: %s",
+                  name,
+                  mamaStatus_stringForStatus (status));
+        goto cleanup_error;
+    }
+    status = mamaDispatcher_create (&impl->mDispatcher, impl->mDispatcherQueue);
+    if (status != MAMA_STATUS_OK) {
+        mama_log(MAMA_LOG_LEVEL_ERROR,
+                  "Failed to create transport dispatcher for %s: %s",
+                  name,
+                  mamaStatus_stringForStatus (status));
+        goto cleanup_error;
+    }
+
+    char paramName[PROPERTY_NAME_MAX_LENGTH];
+    const char* property = NULL;
+
+    property = properties_GetPropertyValueUsingFormatString (
+        mamaInternal_getProperties(),
+        "1000",
+        "mama.ompb.transport.%s.rate",
+        name);
+    uint32_t rate = (uint32_t) atol (property);
+    impl->mPlaybackInterval = 1.0 / (mama_f64_t)rate;
+    mama_log(MAMA_LOG_LEVEL_FINE,
+              "Setting playback rate to %" PRIu32 " msg/s in transport %s",
+              rate,
+              name);
+
+    property = properties_GetPropertyValueUsingFormatString (
+        mamaInternal_getProperties(),
+        NULL,
+        "mama.ompb.transport.%s.file",
+        name);
+    if (NULL == property) {
+        mama_log(MAMA_LOG_LEVEL_ERROR,
+                  "Property configuration for %s not found - cannot playback",
+                  paramName);
+        goto cleanup_error;
+    } else {
+        mama_log(MAMA_LOG_LEVEL_FINE,
+                  "Using playback file '%s' for transport %s",
+                  property,
+                  name);
+        impl->mFileName = strdup(property);
+    }
+
+    property = properties_GetPropertyValueUsingFormatString (
+        mamaInternal_getProperties(),
+        "raise",
+        "mama.ompb.transport.%s.on_completion",
+        name);
+    if (0 == strcasecmp(property, "raise")) {
+        impl->mRewindEnabled = 0;
+        impl->mRaiseEnabled = 1;
+        mama_log(MAMA_LOG_LEVEL_FINE,
+                  "Using enabling raise on completion for transport %s",
+                  property,
+                  name);
+    }
+    else if (0 == strcasecmp(property, "rewind")) {
+        impl->mRewindEnabled = 1;
+        impl->mRaiseEnabled = 0;
+        mama_log(MAMA_LOG_LEVEL_FINE,
+                  "Using rewind on completion for transport %s",
+                  property,
+                  name);
+    } else {
+        mama_log(MAMA_LOG_LEVEL_FINE,
+                  "Invalid on_completion - defaulting to 'raise' "
+                  "for transport %s",
+                  property,
+                  name);
+        impl->mRewindEnabled = 0;
+        impl->mRaiseEnabled = 1;
+    }
+
+    // Initialize lock and create subscriptions table inside
+    wthread_mutex_init(&impl->mSubscriptionsLock, NULL);
+    wthread_mutex_lock (&impl->mSubscriptionsLock);
+    impl->mSubscriptions = wtable_create("ompbsubs", 1024);
+    wthread_mutex_unlock (&impl->mSubscriptionsLock);
+
+    /* Allocate a new playback file parser for the new instrument. */
+    status = mamaPlaybackFileParser_allocate (&impl->mFileParser);
+    if (MAMA_STATUS_OK != status)
+    {
+        mama_log (MAMA_LOG_LEVEL_ERROR,
+                  "Could not allocate file parser for transport: %s",
+                  name);
+        goto cleanup_error;
+    }
+
+    /* Open the playback file for the instrument */
+    status = mamaPlaybackFileParser_openFile (impl->mFileParser,
+                                              (char*)impl->mFileName);
+    if (MAMA_STATUS_OK != status)
+    {
+        mama_log (MAMA_LOG_LEVEL_WARN,
+                  "Could not open playback file '%s' for transport: %s",
+                  impl->mFileName,
+                  name);
+        goto cleanup_error;
+    }
+
+    status = mamaTimer_create (&impl->mDispatcherTimer,
+                               impl->mDispatcherQueue,
+                               ompbBridgeMamaTransportImpl_dispatchThread,
+                               impl->mPlaybackInterval,
+                               impl);
+    if (status != MAMA_STATUS_OK) {
+        mama_log(MAMA_LOG_LEVEL_ERROR,
+                  "Failed to create transport timer for %s: %s",
+                  name,
+                  mamaStatus_stringForStatus (status));
+        goto cleanup_error;
+    }
+
+    impl->mIsValid = 1;
+    return MAMA_STATUS_OK;
+
+cleanup_error:
+    free (*result);
+    if (NULL != impl->mDispatcherTimer) {
+        mamaTimer_destroy(impl->mDispatcherTimer);
+    }
+
+    if (NULL != impl->mDispatcher) {
+        mamaDispatcher_destroy (impl->mDispatcher);
+    }
+
+    if (NULL != impl->mDispatcherQueue) {
+        mamaQueue_destroy(impl->mDispatcherQueue);
+    }
+
+    if (NULL != impl->mFileParser) {
+        mamaPlaybackFileParser_closeFile (impl->mFileParser);
+        mamaPlaybackFileParser_deallocate (impl->mFileParser);
+    }
+    return MAMA_STATUS_PLATFORM;
+}

--- a/mama/c_cpp/src/c/bridge/ompb/transport.h
+++ b/mama/c_cpp/src/c/bridge/ompb/transport.h
@@ -1,0 +1,54 @@
+/* $Id$
+ *
+ * OpenMAMA: The open middleware agnostic messaging API
+ * Copyright (C) 2011 NYSE Technologies, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+#ifndef MAMA_BRIDGE_OMPB_TRANSPORT_H__
+#define MAMA_BRIDGE_OMPB_TRANSPORT_H__
+
+
+/*=========================================================================
+  =                             Includes                                  =
+  =========================================================================*/
+
+#include <mama/mama.h>
+#include <bridge.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * Register a subscription on this transport for the given source.topic
+ * identifier as a string.
+ *
+ * @param transport     The transport bridge to use
+ * @param identifier    The subscription string in source.topic format
+ * @param sub           The mama subscription to register
+ */
+void
+ompbBridgeMamaTransportImpl_registerSubscription(transportBridge transport,
+                                                 const char* identifier,
+                                                 mamaSubscription sub);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* MAMA_BRIDGE_OMPB_TRANSPORT_H__*/

--- a/mama/c_cpp/src/examples/mama.properties
+++ b/mama/c_cpp/src/examples/mama.properties
@@ -35,10 +35,13 @@ mama.entitlement.portlow=9500
 mama.entitlement.porthigh=9550
 
 ################################################################################
-# Example MAMA properties for AVIS messaging middleware
+# Example MAMA properties for OpenMAMA Playback bridge
 ################################################################################
-# URL for the avis router - default value is elvin://127.0.0.1
-#mama.avis.transport.url=elvin://host1:5555
+
+mama.ompb.transport.pb.file = /path/to/playback.mplay
+mama.ompb.transport.pb.rate = 1000
+mama.ompb.transport.pb.on_completion = rewind
+# mama.ompb.transport.pb.on_completion = raise
 
 ################################################################################
 # Example MAMA properties for QPID messaging middleware


### PR DESCRIPTION
This bridge will help allow users to test their applications without having
to set up an out-of-process publisher to connect to. It can be built by adding
the following option to cmake:

    -DWITH_OMPB_BRIDGE=ON

And can then be used with `-m ompb` where the following mama.properties config
parameters are supported (given a transport name of 'pb'):

    mama.ompb.transport.pb.file = /path/to/playback.mplay
    mama.ompb.transport.pb.rate = 100000
    mama.ompb.transport.pb.on_completion = rewind

Note that you can also pass "raise" to the on_completion parameter to get the
bridge to raise a SIGINT on playback completion which can then be caught in
your application to clean up the test run.

Signed-off-by: Frank Quinn <fquinn@cascadium.io>