### PR TITLE
Miscellaneous properties and common lib fixes and improvements

### DIFF
--- a/common/c_cpp/src/c/list.c
+++ b/common/c_cpp/src/c/list.c
@@ -78,6 +78,9 @@ list_create (size_t elementSize)
     wListImpl* rval;
 
     rval = malloc (sizeof (wListImpl));
+    if (NULL == rval) {
+        return INVALID_LIST;
+    }
     memset (rval, 0, sizeof (wListImpl));
 
     /* We need to deal with alignment when alocating elements */

--- a/common/c_cpp/src/c/property.c
+++ b/common/c_cpp/src/c/property.c
@@ -265,22 +265,38 @@ properties_GetPropertyValueUsingFormatString (wproperty_t handle,
     /* Populate list with arguments passed in */
     va_start (arguments, format);
 
-    /* Create the complete transport property string */
-    vsnprintf (paramName, PROPERTY_NAME_MAX_LENGTH, format, arguments);
-
-    /* Get the property out for analysis */
-    returnVal = properties_Get (handle, paramName);
-
-    /* Properties will return NULL if property is not specified in configs */
-    if (returnVal == NULL)
-    {
-        returnVal = defaultVal;
-    }
+    returnVal = properties_GetPropertyValueUsingVaList (
+        handle, defaultVal, paramName, format, arguments);
 
     /* Clean up the list */
     va_end(arguments);
 
     return returnVal;
+}
+
+const char* properties_GetPropertyValueUsingVaList (
+    wproperty_t handle,
+    const char* defaultVal,
+    char* paramName,
+    const char* format,
+    va_list arguments)
+{
+    const char* property = NULL;
+
+    /* Create the complete transport property string */
+    vsnprintf (paramName, PROPERTY_NAME_MAX_LENGTH,
+               format, arguments);
+
+    /* Get the property out for analysis */
+    property = properties_Get (handle, paramName);
+
+    /* Properties will return NULL if parameter is not specified in configs */
+    if (property == NULL)
+    {
+        property = defaultVal;
+    }
+
+    return property;
 }
 
 int
@@ -314,6 +330,8 @@ struct propCallbackContainer
 {
     propertiesCallback cb;
     void* closure;
+    const char* prefix;
+    size_t prefixLen;
 };
 
 static void
@@ -323,7 +341,13 @@ propertiesImpl_ForEach( wtable_t props, void* data, const char* key,
     struct propCallbackContainer * container =
 	(struct propCallbackContainer *) cookie;
 
-    (*container->cb)(key, data, container->closure);
+    if (container->prefix == NULL) {
+        (*container->cb)(key, data, container->closure);
+    } else if (0 == strncmp(key, container->prefix, container->prefixLen)
+        && strlen(key) > container->prefixLen) {
+        // Only pass bare key name when using this callback
+        (*container->cb)(key + container->prefixLen, data, container->closure);
+    }
 }
 
 /**
@@ -337,6 +361,25 @@ properties_ForEach( wproperty_t handle, propertiesCallback cb, void* closure)
     propertiesImpl_ *this = (propertiesImpl_ *)handle;
     container.cb = cb;
     container.closure = closure;
+    container.prefix = NULL;
+    container.prefixLen = 0;
+
+    wtable_for_each( this->mTable, propertiesImpl_ForEach, &container );
+}
+
+/**
+ * Iterate over all keys in the properties table matching provided prefix
+ */
+void
+properties_ForEachWithPrefix( wproperty_t handle, const char* prefix, propertiesCallback cb, void* closure)
+{
+    struct propCallbackContainer container;
+
+    propertiesImpl_ *this = (propertiesImpl_ *)handle;
+    container.cb = cb;
+    container.closure = closure;
+    container.prefix = prefix;
+    container.prefixLen = strlen (prefix);
 
     wtable_for_each( this->mTable, propertiesImpl_ForEach, &container );
 }

--- a/common/c_cpp/src/c/property.h
+++ b/common/c_cpp/src/c/property.h
@@ -24,6 +24,7 @@
  
 #include <wombat/wConfig.h>
 #include <wombat/port.h>
+#include <stdarg.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -88,6 +89,16 @@ void
 properties_ForEach( wproperty_t handle, propertiesCallback cb, void* closure);
 
 /**
+ * Iterate over all keys in the properties table matching the given prefix
+ */
+COMMONExpDLL
+void
+properties_ForEachWithPrefix (wproperty_t handle,
+                              const char* prefix,
+                              propertiesCallback cb,
+                              void* closure);
+
+/**
  * Free the resources associated with the properties.
  */
 COMMONExpDLL
@@ -117,6 +128,34 @@ properties_GetPropertyValueUsingFormatString (wproperty_t handle,
                                               const char* defaultVal,
                                               const char* format,
                                               ...);
+
+/**
+ * This is a local function for parsing string configuration parameters from the
+ * properties object, and supports default values. This function should
+ * be used where the configuration parameter itself can be variable.
+ * @param handle     The property file handle to use
+ * @param defaultVal This is the default value to use if the parameter does not
+ *                   exist in the configuration file
+ * @param paramName  The format and variable list combine to form the real
+ *                   configuration parameter used. This configuration parameter
+ *                   will be stored at this location so the calling function
+ *                   can log this.
+ * @param format     This is the format string which is used to build the
+ *                   name of the configuration parameter which is to be parsed.
+ * @param arguments  This is the variable list of arguments to be used along
+ *                   with the format string.
+ *
+ * @return const char* containing the parameter value or the default or NULL if
+ *         it is not found.
+ */
+COMMONExpDLL
+const char*
+properties_GetPropertyValueUsingVaList (
+    wproperty_t handle,
+    const char* defaultVal,
+    char* paramName,
+    const char* format,
+    va_list arguments);
 
 /**
  * Will escape the chars with a \ found to match in chars array. Returns a 

--- a/common/c_cpp/src/c/strutils.c
+++ b/common/c_cpp/src/c/strutils.c
@@ -648,6 +648,20 @@ int strToVersionInfo(const char* s, versionInfo* version)
 }
 
 COMMONExpDLL
+char* wstrsep (char** sp, char* sep)
+{
+    char *p, *s;
+    if (sp == NULL || *sp == NULL || **sp == '\0')
+        return (NULL);
+    s = *sp;
+    p = s + strcspn (s, sep);
+    if (*p != '\0')
+        *p++ = '\0';
+    *sp = p;
+    return (s);
+}
+
+COMMONExpDLL
 char* strReplaceEnvironmentVariable(const char* value)
 {
     /* Returns */

--- a/common/c_cpp/src/c/timers.c
+++ b/common/c_cpp/src/c/timers.c
@@ -404,9 +404,9 @@ int resetTimer (timerHeap heap, timerElement timer, struct timeval* timeout)
 
 int lockTimerHeap (timerHeap heap)
 {
+    timerHeapImpl* heapImpl = (timerHeapImpl*)heap;
     if (heap == NULL)
         return -1;
-    timerHeapImpl* heapImpl = (timerHeapImpl*)heap;
 
     return wthread_mutex_lock (&heapImpl->mLock);
 }
@@ -414,9 +414,9 @@ int lockTimerHeap (timerHeap heap)
 
 int unlockTimerHeap (timerHeap heap)
 {
+    timerHeapImpl* heapImpl = (timerHeapImpl*)heap;
     if (heap == NULL)
         return -1;
-    timerHeapImpl* heapImpl = (timerHeapImpl*)heap;
 
     return wthread_mutex_unlock (&heapImpl->mLock);
 }

--- a/common/c_cpp/src/c/wombat/strutils.h
+++ b/common/c_cpp/src/c/wombat/strutils.h
@@ -168,6 +168,12 @@ int strToVersionInfo(const char* s, versionInfo* version);
 COMMONExpDLL
 char* strReplaceEnvironmentVariable(const char* value);
 
+/**
+ * Portable implementation of strsep which is public domain taken from
+ * https://unixpapa.com/incnote/string.html
+ */
+COMMONExpDLL char* wstrsep (char** sp, char* sep);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/common/c_cpp/src/cpp/CMakeLists.txt
+++ b/common/c_cpp/src/cpp/CMakeLists.txt
@@ -2,12 +2,13 @@ project (wombatcommoncpp)
 
 get_target_property(WOMBAT_INCLUDES wombatcommon INCLUDE_DIRECTORIES)
 include_directories(
-	wombat
-	${WOMBAT_INCLUDES}
+    .
+    ${WOMBAT_INCLUDES}
 )
 
 set(sources
-	Lock.cpp
+    Lock.cpp
+    CommonStrUtils.cpp
 )
 
 add_library(wombatcommoncpp SHARED ${sources})

--- a/common/c_cpp/src/cpp/CommonStrUtils.cpp
+++ b/common/c_cpp/src/cpp/CommonStrUtils.cpp
@@ -1,0 +1,43 @@
+#include <wlock.h>
+#include "wombat/CommonStrUtils.h"
+
+namespace Wombat
+{
+
+std::string&
+CommonStrUtils::ltrim(std::string& s, const char* t)
+{
+    s.erase(0, s.find_first_not_of(t));
+    return s;
+}
+
+std::string&
+CommonStrUtils::rtrim(std::string& s, const char* t)
+{
+    s.erase(s.find_last_not_of(t) + 1);
+    return s;
+}
+
+std::string&
+CommonStrUtils::trim(std::string& s, const char* t)
+{
+    return ltrim(rtrim(s, t), t);
+}
+
+std::vector<std::string>
+CommonStrUtils::split (const char* input, const char* delim) {
+    std::vector<std::string> list;
+    std::string delimiter = delim;
+    std::string s = input;
+    size_t pos;
+    std::string token;
+    while ((pos = s.find(delimiter)) != std::string::npos) {
+        token = s.substr(0, pos);
+        list.push_back(trim(token));
+        s.erase(0, pos + delimiter.length());
+    }
+    list.push_back(trim(s));
+    return list;
+}
+
+}

--- a/common/c_cpp/src/cpp/wombat/CommonStrUtils.h
+++ b/common/c_cpp/src/cpp/wombat/CommonStrUtils.h
@@ -1,0 +1,51 @@
+#ifndef CommonStrUtilsCppH__
+#define CommonStrUtilsCppH__
+
+#include <vector>
+#include <string>
+
+namespace Wombat {
+
+class COMMONExpDLL CommonStrUtils
+{
+public:
+    /**
+     * Removes leading and trailing whitespace from the given string. This is
+     * a non-destructive operation
+     * @param s The original string to examine
+     * @param t The optional list of characters to trim
+     * @return The trimmed string.
+     */
+    static std::string& trim(std::string& s, const char* t = " \t\n\r\f\v");
+
+    /**
+     * Removes leading whitespace from the given string. This is
+     * a non-destructive operation
+     * @param s The original string to examine
+     * @param t The optional list of characters to trim
+     * @return The trimmed string.
+     */
+    static std::string& ltrim(std::string& s, const char* t = " \t\n\r\f\v");
+
+    /**
+     * Removes trailing whitespace from the given string. This is
+     * a non-destructive operation
+     * @param s The original string to examine
+     * @param t The optional list of characters to trim
+     * @return The trimmed string.
+     */
+    static std::string& rtrim(std::string& s, const char* t = " \t\n\r\f\v");
+
+    /**
+     * Splits a given string according to the given delimiter and returns a
+     * vector of strings containing each component separated into separate
+     * string objects.
+     * @param input The string to split
+     * @param delim The character or sequence of characters to split according
+     *              to.
+     * @return A vector containing each component of the split string
+     */
+    static std::vector<std::string> split(const char* input, const char* delim);
+};
+}
+#endif

--- a/mama/c_cpp/src/c/CMakeLists.txt
+++ b/mama/c_cpp/src/c/CMakeLists.txt
@@ -62,6 +62,8 @@ set(sources
 	listenermsgcallback.c
 	log.c
 	mama.c
+	queuegroup.c
+	mama/queuegroup.h
 	mamaStrUtils.c
 	mamautils.c
 	marketdata.c

--- a/mama/c_cpp/src/c/bridge/base/bridge.c
+++ b/mama/c_cpp/src/c/bridge/base/bridge.c
@@ -138,6 +138,9 @@ baseBridge_close (mamaBridge bridgeImpl)
     /* Stop and destroy the io thread */
     baseBridgeMamaIoImpl_stop ((void*)closure);
 
+    /* Free the original closure */
+    free (closure);
+
     return status;
 }
 

--- a/mama/c_cpp/src/c/bridge/qpid/codec.c
+++ b/mama/c_cpp/src/c/bridge/qpid/codec.c
@@ -183,6 +183,7 @@ qpidBridgeMsgCodec_unpack (msgBridge        bridgeMessage,
     baseMsgType         type            = BASE_MSG_PUB_SUB;
     pn_bytes_t          prop;
     pn_atom_t           firstAtom;
+    int                 found = 0;
 
     if (NULL == bridgeMessage || NULL == protonMessage)
     {
@@ -263,7 +264,6 @@ qpidBridgeMsgCodec_unpack (msgBridge        bridgeMessage,
     pn_data_get_map (properties);
     pn_data_enter (properties);
 
-    int found = 0;
     found = pn_data_lookup (properties,QPID_KEY_MSGTYPE);
     if (found)
     {

--- a/mama/c_cpp/src/c/endpointpool.c
+++ b/mama/c_cpp/src/c/endpointpool.c
@@ -483,10 +483,9 @@ endpointPool_getEndpointByIdentifiers   (endpointPool_t     endpoints,
     endpointPoolImpl*       impl             = (endpointPoolImpl*) endpoints;
     wtable_t                registeredTable  = NULL;
     endpoint_t              existingEndpoint = NULL;
+    mama_status status;
 
     wlock_lock(impl->mLock);
-
-    mama_status status;
 
     /* Get the wtable representing the endpoints associated with this topic */
     registeredTable = wtable_lookup (impl->mContainer, topic);
@@ -522,6 +521,7 @@ endpointPoolImpl_extendBuffer (endpointPoolImpl* impl, size_t size)
 {
     size_t  newSize     = 0;
     void*   newBuffer   = NULL;
+    mama_status status;
 
     if (NULL == impl)
     {
@@ -542,7 +542,6 @@ endpointPoolImpl_extendBuffer (endpointPoolImpl* impl, size_t size)
     }
 
     /* Reallocate memory as required */
-    mama_status status;
     newBuffer = realloc (impl->mBuffer, newSize);
     if (NULL == newBuffer)
     {

--- a/mama/c_cpp/src/c/mama/integration/mama.h
+++ b/mama/c_cpp/src/c/mama/integration/mama.h
@@ -237,6 +237,52 @@ mama_status
 mamaImpl_setDefaultEventQueue (mamaBridge bridgeImpl,
                                mamaQueue defaultQueue);
 
+/**
+ * This is a local function for parsing long configuration parameters from the
+ * MAMA properties object, and supports minimum and maximum limits as well
+ * as default values to reduce the amount of code duplicated throughout.
+ *
+ * @param defaultVal This is the default value to use if the parameter does not
+ *                   exist in the configuration file
+ * @param minimum    If the parameter obtained from the configuration file is
+ *                   less than this value, this value will be used.
+ * @param maximum    If the parameter obtained from the configuration file is
+ *                   greater than this value, this value will be used.
+ * @param format     This is the format string which is used to build the
+ *                   name of the configuration parameter which is to be parsed.
+ * @param ...        This is the variable list of arguments to be used along
+ *                   with the format string.
+ *
+ * @return long int containing the parameter value, default, minimum or maximum.
+ */
+MAMAExpDLL
+extern long int
+mamaImpl_getParameterAsLong (
+    long defaultVal,
+    long minimum,
+    long maximum,
+    const char* format, ...);
+
+/**
+ * This is a local function for parsing string configuration parameters from the
+ * MAMA properties object, and supports default values. This function should
+ * be used where the configuration parameter itself can be variable.
+ *
+ * @param defaultVal This is the default value to use if the parameter does not
+ *                   exist in the configuration file
+ * @param format     This is the format string which is used to build the
+ *                   name of the configuration parameter which is to be parsed.
+ * @param ...        This is the variable list of arguments to be used along
+ *                   with the format string.
+ *
+ * @return const char* containing the parameter value or the default.
+ */
+MAMAExpDLL
+extern const char*
+mamaImpl_getParameter (
+    const char* defaultVal,
+    const char* format, ...);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/mama/c_cpp/src/c/mama/mama.h
+++ b/mama/c_cpp/src/c/mama/mama.h
@@ -69,6 +69,8 @@ extern "C"
 #define MAMA_MAX_ROOT_LEN          5 // e.g. _MDDD
 #define MAMA_MAX_SOURCE_LEN        64
 #define MAMA_MAX_TRANSPORT_LEN     64
+#define MAMA_MAX_BRIDGE_NAME_LEN   64
+#define MAMA_MAX_RESOURCE_POOL_LEN 128
 // This is source + symbol + root + 2 delimiting periods
 #define MAMA_MAX_TOTAL_SYMBOL_LEN  (MAMA_MAX_SYMBOL_LEN + MAMA_MAX_SOURCE_LEN + \
                                     MAMA_MAX_ROOT_LEN + 2)

--- a/mama/c_cpp/src/c/mama/subscription.h
+++ b/mama/c_cpp/src/c/mama/subscription.h
@@ -270,7 +270,7 @@ typedef struct mamaMsgCallbacks_
     wombat_subscriptionQualityCB  onQuality;
     wombat_subscriptionGapCB      onGap;
     wombat_subscriptionRecapCB    onRecapRequest;
-	wombat_subscriptionDestroyCB  onDestroy;
+    wombat_subscriptionDestroyCB  onDestroy;
 } mamaMsgCallbacks;
 
 /**

--- a/mama/c_cpp/src/c/mama/types.h
+++ b/mama/c_cpp/src/c/mama/types.h
@@ -48,6 +48,9 @@ typedef uint32_t        mama_seqnum_t;
 
 #define MAMA_QUANTITY_EPSILON   ((mama_f64_t)0.00000000001)
 
+#define MAMA_BOOL_TRUE 1
+#define MAMA_BOOL_FALSE 0
+
 /**
  * Macro to determine if a quantity is zero
  */
@@ -134,6 +137,7 @@ typedef struct mamaStatImpl_*                   mamaStat;
 typedef struct mamaStatsCollectorImpl_*         mamaStatsCollector;
 typedef struct mamaStatsGeneratorImpl_*         mamaStatsGenerator;
 typedef struct mamaMsgReplyImpl_*               mamaMsgReply;
+typedef struct mamaQueueGroupImpl_*             mamaQueueGroup;
 
 typedef struct mamaVersion {
     int     mMajor;

--- a/mama/c_cpp/src/c/mamainternal.h
+++ b/mama/c_cpp/src/c/mamainternal.h
@@ -35,7 +35,7 @@
   #define OPENMAMA_INTEGRATION
 #endif
 
-#include <mama/integration/mama.h>
+#include "mama/integration/mama.h"
 
 #if defined(__cplusplus)
 extern "C"

--- a/mama/c_cpp/src/c/payload/qpidmsg/qpidcommon.c
+++ b/mama/c_cpp/src/c/payload/qpidmsg/qpidcommon.c
@@ -41,7 +41,7 @@
   =                  Public implementation functions                      =
   =========================================================================*/
 
-inline void
+void
 qpidmsgPayloadInternal_checkLengthAndIncDest (mama_size_t  written,
                                               mama_size_t* length,
                                               char**       dest)

--- a/mama/c_cpp/src/cpp/CMakeLists.txt
+++ b/mama/c_cpp/src/cpp/CMakeLists.txt
@@ -1,9 +1,11 @@
 project (mamacpp)
 
+get_target_property(WOMBAT_INCLUDES wombatcommoncpp INCLUDE_DIRECTORIES)
 get_target_property(MAMA_INCLUDES mama INCLUDE_DIRECTORIES)
 
 include_directories(
 	${CMAKE_CURRENT_SOURCE_DIR}
+	${WOMBAT_INCLUDES}
 	${MAMA_INCLUDES}
 )
 
@@ -58,7 +60,7 @@ set(sources
 
 add_library(mamacpp SHARED ${sources})
 add_library(mamacppstatic STATIC ${sources})
-target_link_libraries(mamacpp mama)
+target_link_libraries(mamacpp mama wombatcommoncpp)
 target_link_libraries(mamacppstatic mamastatic)
 
 set_target_properties(mamacpp PROPERTIES OUTPUT_NAME "mamacpp${OPENMAMA_LIBRARY_SUFFIX}")

--- a/mama/c_cpp/src/cpp/MamaMsg.cpp
+++ b/mama/c_cpp/src/cpp/MamaMsg.cpp
@@ -2037,7 +2037,8 @@ void MamaMsg::method (const MamaFieldDescriptor* field, fType value)   \
 
     const char* MamaMsg::toJsonString (const MamaDictionary*  dictionary) const
     {
-        mString = mamaMsg_toJsonStringWithDictionary (mMsg, dictionary->getDictC());
+        mamaDictionary cDictionary = dictionary == nullptr ? nullptr : dictionary->getDictC();
+        mString = mamaMsg_toJsonStringWithDictionary (mMsg, cDictionary);
         return mString;
     }
 

--- a/mama/c_cpp/src/cpp/mama/MamaBasicSubscriptionCallback.h
+++ b/mama/c_cpp/src/cpp/mama/MamaBasicSubscriptionCallback.h
@@ -23,6 +23,7 @@
 #define MAMA_BASIC_SUBSCRIPTION_CALLBACK_CPP_H__
 
 #include "mama/mamacpp.h"
+#include "mama/MamaStatus.h"
 
 namespace Wombat 
 {

--- a/mama/c_cpp/src/cpp/mama/MamaStatus.h
+++ b/mama/c_cpp/src/cpp/mama/MamaStatus.h
@@ -22,7 +22,8 @@
 #ifndef MAMA_STATUS_CPP_H__
 #define MAMA_STATUS_CPP_H__
 
-#include "mama/mamacpp.h"
+#include <mama/status.h>
+#include <exception>
 
 namespace Wombat 
 {

--- a/mama/c_cpp/src/cpp/mama/MamaSubscription.h
+++ b/mama/c_cpp/src/cpp/mama/MamaSubscription.h
@@ -30,6 +30,7 @@ namespace Wombat
     class MamaSubscriptionCallback;
     class MamaSource;
     class MamaSourceDerivative;
+    class MamaTransport;
 
     struct MamaSubscriptionImpl;
     /**

--- a/mama/c_cpp/src/cpp/mama/MamaSubscriptionCallback.h
+++ b/mama/c_cpp/src/cpp/mama/MamaSubscriptionCallback.h
@@ -22,11 +22,13 @@
 #ifndef MAMA_SUBSCRIPTION_CALLBACK_CPP_H__
 #define MAMA_SUBSCRIPTION_CALLBACK_CPP_H__
 
+#include "mama/MamaStatus.h"
 #include "mama/mamacpp.h"
 
 namespace Wombat 
 {
     class MamaSubscription;
+    class MamaBasicSubscription;
     /**
      * The message callback interface. Callers provide an object implementing this 
      * interface on creating a <code>MamaSubscription</code>.

--- a/mama/c_cpp/src/cpp/mama/mamacpp.h
+++ b/mama/c_cpp/src/cpp/mama/mamacpp.h
@@ -22,8 +22,10 @@
 #ifndef MAMA_CPP_H__
 #define MAMA_CPP_H__
 
-#include <stdio.h>
+#include <cstdio>
 #include <cstring>
+#include <string>
+#include <map>
 
 #include <mama/mama.h>
 #include <mama/MamaBridgeCallback.h>
@@ -440,7 +442,7 @@ public:
     static void stop (mamaBridge bridgeImpl);
 
 
-     /**
+    /**
      * Stop dispatching on the default event queue for all bridges.
      */
     static void stopAll (void);

--- a/mama/c_cpp/src/cpp/mamacpp.cpp
+++ b/mama/c_cpp/src/cpp/mamacpp.cpp
@@ -33,6 +33,7 @@
 #include <mama/queue.h>
 #include <mama/MamaQueue.h>
 #include <mama/MamaReservedFields.h>
+#include <map>
 
 namespace Wombat
 {

--- a/mama/c_cpp/src/gunittest/c/CMakeLists.txt
+++ b/mama/c_cpp/src/gunittest/c/CMakeLists.txt
@@ -98,9 +98,24 @@ UnitTestC(UnitTestMamaPayloadC
 	payload/payloadgeneraltests.cpp
 	payload/payloadvectortests.cpp
 )
+target_link_libraries(UnitTestMamaC ${GTEST_BOTH_LIBRARIES} mama)
+install(TARGETS UnitTestMamaC
+		RUNTIME DESTINATION bin
+		LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib)
+if (WIN32 AND MSVC)
+	install(FILES $<TARGET_PDB_FILE:UnitTestMamaC> DESTINATION bin OPTIONAL)
+endif()
+
+gtest_discover_tests(
+		UnitTestMamaC
+	EXTRA_ARGS -m qpid -p qpidmsg -i Q
+	PROPERTIES ENVIRONMENT
+		"WOMBAT_PATH=${CMAKE_SOURCE_DIR}/mama/c_cpp/src/examples:${CMAKE_SOURCE_DIR}/mama/c_cpp/src/gunittest/c"
+)
 
 if (WIN32)
-    set(BATCH_ENV_PATH "${GTEST_ROOT}/bin;${APR_ROOT}/bin;${PROTON_ROOT}/bin;${LIBEVENT_ROOT}/lib;$<TARGET_FILE_DIR:mama>;$<TARGET_FILE_DIR:wombatcommon>;$<TARGET_FILE_DIR:mamabaseimpl>;$<TARGET_FILE_DIR:mamaqpidimpl>;$<TARGET_FILE_DIR:mamaplugindqstrategy>;$<TARGET_FILE_DIR:mamaentnoop>;$<TARGET_FILE_DIR:mamaqpidmsgimpl>")
+    set(BATCH_ENV_PATH "${GTEST_ROOT}/bin;${APR_ROOT}/bin;${APRUTIL_ROOT}/bin;${PROTON_ROOT}/bin;${LIBEVENT_ROOT}/lib;$<TARGET_FILE_DIR:mama>;$<TARGET_FILE_DIR:wombatcommon>;$<TARGET_FILE_DIR:wombatcommoncpp>;$<TARGET_FILE_DIR:mamabaseimpl>;$<TARGET_FILE_DIR:mamaqpidimpl>;$<TARGET_FILE_DIR:mamaplugindqstrategy>;$<TARGET_FILE_DIR:mamaentnoop>;$<TARGET_FILE_DIR:mamaqpidmsgimpl>")
 	if (WITH_MAMDA)
 		set(BATCH_ENV_PATH "${BATCH_ENV_PATH};$<TARGET_FILE_DIR:mamda>")
 	endif()

--- a/mama/c_cpp/src/gunittest/c/MainUnitTestC.cpp
+++ b/mama/c_cpp/src/gunittest/c/MainUnitTestC.cpp
@@ -40,9 +40,9 @@
 static string version     ("APPNAMESTR:  Version " VERSIONSTR
                            "  Date " DATESTR "  Build " BUILDSTR);
 
-static const char*       gMiddleware = "wmw";
-static const char*       gPayload    = "wmsg";
-static char              gPayloadId  = 'W';
+static const char*       gMiddleware = "qpid";
+static const char*       gPayload    = "qpidmsg";
+static char              gPayloadId  = 'Q';
 static const char*       gTransport  = "tport";
 static gtest_strictness  gStrictness  = DISCRETIONAL;
 static const char*       gSymbol     = "SYM";

--- a/mama/c_cpp/src/gunittest/c/middleware/middlewareInboxTests.cpp
+++ b/mama/c_cpp/src/gunittest/c/middleware/middlewareInboxTests.cpp
@@ -69,7 +69,7 @@ void MAMACALLTYPE onError(mama_status status, void *closure)
 {
 }
 
-void MAMACALLTYPE onInboxDestroy(mamaInbox inbox, void *closure)
+void MAMACALLTYPE onMwInboxDestroy(mamaInbox inbox, void *closure)
 {
 }
 
@@ -104,7 +104,7 @@ TEST_F (MiddlewareInboxTests, create)
                                               queue,
                                               onMsg,
                                               onError,
-                                              onInboxDestroy,
+                                              onMwInboxDestroy,
                                               closure,
                                               parent));
 
@@ -324,7 +324,7 @@ TEST_F (MiddlewareInboxTests, CreateDestroy)
                                               queue,
                                               onMsg,
                                               onError,
-                                              onInboxDestroy,
+                                              onMwInboxDestroy,
                                               closure,
                                               parent));
 

--- a/mama/c_cpp/src/gunittest/c/middleware/middlewareIoTests.cpp
+++ b/mama/c_cpp/src/gunittest/c/middleware/middlewareIoTests.cpp
@@ -61,7 +61,7 @@ void MiddlewareIoTests::TearDown(void)
     mama_close();
 }
 
-void MAMACALLTYPE onIo(mamaIo io, mamaIoType ioType, void* closure)
+void MAMACALLTYPE onMwIo(mamaIo io, mamaIoType ioType, void* closure)
 {
 }
 
@@ -81,11 +81,11 @@ TEST_F (MiddlewareIoTests, create)
               mamaQueue_create(&queue, mBridge));
 
     ASSERT_EQ(MAMA_STATUS_OK,
-              mamaIo_create(&parent, queue, descriptor, onIo, ioType, closure));
+              mamaIo_create(&parent, queue, descriptor, onMwIo, ioType, closure));
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaIoCreate(&io,queue, descriptor,
-                                          onIo, ioType, parent, closure));
+                                            onMwIo, ioType, parent, closure));
     ASSERT_EQ(MAMA_STATUS_OK, mBridge->bridgeMamaIoDestroy(io));
 
     ASSERT_EQ(MAMA_STATUS_OK, mamaIo_destroy(parent));
@@ -102,7 +102,7 @@ TEST_F (MiddlewareIoTests, createInvalidResult)
 
     ASSERT_EQ(MAMA_STATUS_NULL_ARG,
               mBridge->bridgeMamaIoCreate(NULL, queue, descriptor,
-                                          onIo, ioType, parent, closure));
+                                            onMwIo, ioType, parent, closure));
 }
 
 /* THIS WAS COMMENTED OUT BECAUSE mamaIoType CANNOT BE CAST AS NULL.
@@ -134,11 +134,11 @@ TEST_F (MiddlewareIoTests, getDescriptor)
               mamaQueue_create(&queue, mBridge));
 
     ASSERT_EQ(MAMA_STATUS_OK,
-              mamaIo_create(&parent, queue, descriptor, onIo, ioType, closure));
+              mamaIo_create(&parent, queue, descriptor, onMwIo, ioType, closure));
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaIoCreate(&io,queue, descriptor,
-                                          onIo, ioType, parent, closure));
+                                            onMwIo, ioType, parent, closure));
 
     ASSERT_EQ (MAMA_STATUS_OK, 
                mBridge->bridgeMamaIoGetDescriptor(io,&result));
@@ -179,11 +179,11 @@ TEST_F (MiddlewareIoTests, createDestroy)
     ASSERT_EQ(MAMA_STATUS_OK, mamaQueue_create(&queue, mBridge));
 
     ASSERT_EQ(MAMA_STATUS_OK,
-              mamaIo_create(&parent, queue, descriptor, onIo, ioType, closure));
+              mamaIo_create(&parent, queue, descriptor, onMwIo, ioType, closure));
 
     ASSERT_EQ(MAMA_STATUS_OK,
               mBridge->bridgeMamaIoCreate(&io,queue, descriptor,
-                                          onIo, ioType, parent, closure));
+                                            onMwIo, ioType, parent, closure));
 
     ASSERT_EQ (MAMA_STATUS_OK, mBridge->bridgeMamaIoDestroy(io));
 

--- a/mama/c_cpp/src/gunittest/cpp/MainUnitTestCpp.cpp
+++ b/mama/c_cpp/src/gunittest/cpp/MainUnitTestCpp.cpp
@@ -38,12 +38,12 @@
 static string version     ("APPNAMESTR:  Version " VERSIONSTR
                            "  Date " DATESTR "  Build " BUILDSTR);
 
-static const char*  gMiddleware = "wmw";
+static const char*  gMiddleware = "qpid";
 static const char*  gTransport = "test_tport";
 static const char*  gSource = "SRC";
 static const char*  gSymbol = "SYM";
 static const char*  gBadSource = "BADSRC";
-static const char*  gPayload = "wmsg";
+static const char*  gPayload = "qpidmsg";
 
 const char* getMiddleware (void) { return gMiddleware; }
 const char* getTransport (void) { return gTransport; }


### PR DESCRIPTION
- Added NULL check in list_create
- Moved properties_GetPropertyValueUsingVaList from qpid to properties
  common
- Added properties_ForEachWithPrefix to allow parsing properties with a
  prefix from the properties tables
- Add wstrsep as a portable version of strsep
- Removed C mixed declarations
- Added CommonStrUtils CPP library with string trimming functions
- Added mamaImpl_getParameter and mamaImpl_getParameterAsLong
  (integration header only)
- Added MAMA_BOOL_TRUE and MAMA_BOOL_FALSE
- Added fix to MamaMsg::toJsonString for cases where dictionary is null

Signed-off-by: Frank Quinn <fquinn@cascadium.io>