### PR TITLE
Bugfix for Java MamaMsg.createFromByteBuffer and setNewBuffer

### DIFF
--- a/mama/jni/src/c/mamapricejni.c
+++ b/mama/jni/src/c/mamapricejni.c
@@ -138,6 +138,7 @@ JNIEXPORT void JNICALL Java_com_wombat_mama_MamaPrice_setFromString
                 "Error calling MamaPrice.setFromString().",
                 status);
         utils_throwExceptionForMamaStatus(env,status,errorString);
+        return;
     }
 
     /*Tidy up all local refs*/

--- a/mama/jni/src/main/java/com/wombat/mama/MamaMsg.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaMsg.java
@@ -102,6 +102,7 @@ public class MamaMsg
     /* Pointer to the underlying C structure of the reuseable objects */
     private long dateTimePointer_i = 0;
     private long pricePointer_i    = 0;
+    private long byteBufferPointer_i = 0;
 
     /* Pointer to an array of reuseable JNI Msg Objects for extracting
     vector messages */


### PR DESCRIPTION
The createFromByteBuffer implementation never really looks like it worked
property because it reused the same underlying c static buffer for all
calls to it, and it could not be re-used. This version will handle the
operation property by allowing the Java object to track the associated
memory.

Signed-off-by: Frank Quinn <fquinn@cascadium.io>