### PR TITLE
Added mama.startAll and mama.stopAll for C, C++, C# and Java

### DIFF
--- a/mama/c_cpp/src/c/mama/mama.h
+++ b/mama/c_cpp/src/c/mama/mama.h
@@ -398,6 +398,20 @@ extern "C"
     mama_start (mamaBridge bridgeImpl);
 
     /**
+     * Start processing messages on the internal queue for all currently loaded
+     * MAMA bridges. This starts Mama's internal throttle, refresh logic, and
+     * other internal Mama processes as well as dispatching messages from the
+     * internal queue.
+     * <p>
+     * mama_startAll( ) blocks until all currently outstandin
+     *
+     * @param bridgeImpl The bridge specific structure.
+     */
+    MAMAExpDLL
+    extern mama_status
+    mama_startAll (mama_bool_t isBlocking);
+
+    /**
      * The callback invoked if an error occurs calling mama_startBackground() or
      * when mama_startBackground() exits normally in which case status will be
      * MAMA_STATUS_OK.

--- a/mama/c_cpp/src/cpp/mama/mamacpp.h
+++ b/mama/c_cpp/src/cpp/mama/mamacpp.h
@@ -418,6 +418,15 @@ public:
     static void start (mamaBridge bridgeImpl);
 
     /**
+     * Calls Mama::start for all currently loaded middleware bridges
+     *
+     * This function is thread safe.
+     *
+     * @param[in] isBlocking Whether to start blocking or run in background
+     */
+    static void startAll (bool isBlocking = true);
+
+    /**
      * Start processing MAMA internal events in the background. This
      * method invokes Mama::start () in a separate thread.
      *

--- a/mama/c_cpp/src/cpp/mamacpp.cpp
+++ b/mama/c_cpp/src/cpp/mamacpp.cpp
@@ -262,6 +262,11 @@ namespace Wombat
         mamaTry (mama_start (bridgeImpl));
     }
 
+    void Mama::startAll (bool isBlocking)
+    {
+        mamaTry (mama_startAll((mama_bool_t)isBlocking));
+    }
+
     extern "C"
     {
         void MAMACALLTYPE stopCb (mama_status status, mamaBridge, void* closure)
@@ -281,7 +286,7 @@ namespace Wombat
         mamaTry (mama_stop (bridgeImpl));
     }
 
-    void Mama::stopAll (void)
+    void Mama::stopAll ()
     {
         mamaTry (mama_stopAll ());
     }

--- a/mama/dotnet/src/cs/ISourceManager.cs
+++ b/mama/dotnet/src/cs/ISourceManager.cs
@@ -24,56 +24,58 @@ using System;
 namespace Wombat
 {
 	/// <summary>
-	/// A container of <see cref="MamaSource">MamaSource</see> objects. Because each MamaSource can
-	/// contain sub-sources (and so on), MamaSource is also a source
-	/// manager and implements this interface.
+	///     A container of <see cref="MamaSource">MamaSource</see> objects. Because each MamaSource can
+	///     contain sub-sources (and so on), MamaSource is also a source
+	///     manager and implements this interface.
 	/// </summary>
 	public interface ISourceManager : IDisposable
-	{
-		/// <summary>
-		/// Create a new <see cref="MamaSource">MamaSource</see> and add it to the manager.
-		/// </summary>
-		/// <param name="name">The string identifier for the MamaSource.</param>
-		/// <returns>The created MamaSource object if execution is successful.</returns>
-		MamaSource create(string name);
+    {
+	    /// <summary>
+	    ///     Create a new <see cref="MamaSource">MamaSource</see> and add it to the manager.
+	    /// </summary>
+	    /// <param name="name">The string identifier for the MamaSource.</param>
+	    /// <returns>The created MamaSource object if execution is successful.</returns>
+	    MamaSource create(string name);
 
-		/// <summary>
-		/// Locates an existing <see cref="MamaSource">MamaSource</see> for the given name. If none exists creates
-		/// and adds a new MamaSource.
-		/// </summary>
-		/// <param name="name">The string identifier for the MamaSource</param>
-		/// <returns>The MamaSource object if execution is successful.</returns>
-		MamaSource findOrCreate(string name);
+	    /// <summary>
+	    ///     Locates an existing <see cref="MamaSource">MamaSource</see> for the given name. If none exists creates
+	    ///     and adds a new MamaSource.
+	    /// </summary>
+	    /// <param name="name">The string identifier for the MamaSource</param>
+	    /// <returns>The MamaSource object if execution is successful.</returns>
+	    MamaSource findOrCreate(string name);
 
-		/// <summary>
-		/// Locates an existing <see cref="MamaSource">MamaSource</see> with the specified string 'name' identifier.
-		/// Returns null if no source was located.
-		/// </summary>
-		/// <param name="name">The string identifier for the required MamaSource</param>
-		/// <returns>The MamaSource object if found, or null if not found
-		/// (if execution is successful)</returns>
-		MamaSource find(string name);
+	    /// <summary>
+	    ///     Locates an existing <see cref="MamaSource">MamaSource</see> with the specified string 'name' identifier.
+	    ///     Returns null if no source was located.
+	    /// </summary>
+	    /// <param name="name">The string identifier for the required MamaSource</param>
+	    /// <returns>
+	    ///     The MamaSource object if found, or null if not found
+	    ///     (if execution is successful)
+	    /// </returns>
+	    MamaSource find(string name);
 
-		/// <summary>
-		/// Add an existing <see cref="MamaSource">MamaSource</see>.
-		/// The id of the source will be used instead of the name to uniquely identify
-		/// the source within the manager.
-		/// </summary>
-		/// <param name="source">The <see cref="MamaSource">MamaSource</see> being added</param>
-		void add(MamaSource source);
+	    /// <summary>
+	    ///     Add an existing <see cref="MamaSource">MamaSource</see>.
+	    ///     The id of the source will be used instead of the name to uniquely identify
+	    ///     the source within the manager.
+	    /// </summary>
+	    /// <param name="source">The <see cref="MamaSource">MamaSource</see> being added</param>
+	    void add(MamaSource source);
 
-		/// <summary>
-		/// Add an existing <see cref="MamaSource">MamaSource</see> using the specified name as a unique identifier.
-		/// </summary>
-		/// <param name="name">The string identifier for the MamaSource</param>
-		/// <param name="source">The MamaSource being added</param>
-		void add(string name, MamaSource source);
+	    /// <summary>
+	    ///     Add an existing <see cref="MamaSource">MamaSource</see> using the specified name as a unique identifier.
+	    /// </summary>
+	    /// <param name="name">The string identifier for the MamaSource</param>
+	    /// <param name="source">The MamaSource being added</param>
+	    void add(string name, MamaSource source);
 
-		// NB:
-		// the destroy method does not belong here because if we decide to
-		// expose an ISourceManager property from the MamaSource the user would be
-		// able to destroy the underlying source manager in the source, which should
-		// not be possible; hence, the destroy method exists in the MamaSource and
-		// MamaSourceManager classes
-	}
+        // NB:
+        // the destroy method does not belong here because if we decide to
+        // expose an ISourceManager property from the MamaSource the user would be
+        // able to destroy the underlying source manager in the source, which should
+        // not be possible; hence, the destroy method exists in the MamaSource and
+        // MamaSourceManager classes
+    }
 }

--- a/mama/dotnet/src/cs/MAMA.cs
+++ b/mama/dotnet/src/cs/MAMA.cs
@@ -293,6 +293,8 @@ namespace Wombat
         /// </summary>
 #if _GNU
         public const string DllName = "mama";
+#elif _OSX
+        public const string DllName = "mama";
 #elif DEBUG
 		public const string DllName = "libmamacmdd.dll";
 #else
@@ -458,6 +460,31 @@ namespace Wombat
             MamaWrapper.CheckResultCode(NativeMethods.mama_start(bridgeImpl.NativeHandle));
         }
 
+		/// <summary>
+		/// Starts and starts dispatching on all currently loaded MAMA bridges and blocks until they have been stopped.
+		/// </summary>
+        public static void startAll()
+        {
+	        MamaWrapper.CheckResultCode(NativeMethods.mama_startAll(true));
+        }
+
+        /// <summary>
+		/// Starts and starts dispatching on all currently loaded MAMA bridges and optionally blocks until they have
+		/// been stopped.
+		/// </summary>
+        public static void startAll(bool isBlocking)
+        {
+	        MamaWrapper.CheckResultCode(NativeMethods.mama_startAll(isBlocking));
+        }
+
+        /// <summary>
+		/// Stops dispatching for all currently started MAMA bridges.
+		/// </summary>
+        public static void stopAll()
+        {
+	        MamaWrapper.CheckResultCode(NativeMethods.mama_stopAll());
+        }
+        
 		/// <summary>
         ///
         /// Close MAMA and free all associated resource.
@@ -875,16 +902,22 @@ namespace Wombat
 			public static extern int mama_setProperty (string name, string value);
             [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
 			public static extern IntPtr mama_getProperty (string name);
+			[DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+            public static extern void mama_freeAllocatedBuffer (IntPtr buffer);
             [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
 			public static extern IntPtr mama_getVersion (IntPtr bridgeImpl);
             [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
 			public static extern int mama_close();
             [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
 			public static extern int mama_start (IntPtr bridgeImpl);
+			[DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+			public static extern int mama_startAll(bool isBlocking);
             [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
             public static extern int mama_startBackground(IntPtr bridgeImpl, StartBackgroundCallbackForwarder.StartBackgroundCompleteDelegate callback);
             [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
 			public static extern int mama_stop (IntPtr bridgeImpl);
+			[DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
+			public static extern int mama_stopAll();
 			[DllImport(DllName, CallingConvention=CallingConvention.Cdecl)]
 			public static extern int mama_enableLogging (IntPtr f, int level);
             [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]

--- a/mama/dotnet/src/cs/MamaBasicSubscription.cs
+++ b/mama/dotnet/src/cs/MamaBasicSubscription.cs
@@ -19,7 +19,7 @@
  * 02110-1301 USA
  */
 
-﻿
+ 
 using System;
 using System.Runtime.InteropServices;
 
@@ -279,7 +279,7 @@ namespace Wombat
         /// <param name="closure">
         /// The native closure passed to the create function.
         /// </param>
-        protected delegate void OnSubscriptionCreateDelegate(IntPtr nativeHandle, IntPtr closure);
+        public delegate void OnSubscriptionCreateDelegate(IntPtr nativeHandle, IntPtr closure);
 
         /// <summary>
         /// This delegate describes the native function invoked whenever the subscription has been either
@@ -291,7 +291,7 @@ namespace Wombat
         /// <param name="closure">
         /// The native closure passed to the create function.
         /// </param>
-        protected delegate void OnSubscriptionDestroyDelegate(IntPtr nativeHandle, IntPtr closure);
+        public delegate void OnSubscriptionDestroyDelegate(IntPtr nativeHandle, IntPtr closure);
 
         /// <summary>
         /// This delegate describes the native function invoked if an error occurs during prior to subscription
@@ -315,7 +315,7 @@ namespace Wombat
         /// <param name="closure">
         /// The native closure passed to the create function.
         /// </param>
-        protected delegate void OnSubscriptionErrorDelegate(IntPtr nativeHandle, int status, IntPtr platformError, string subject, IntPtr closure);
+        public delegate void OnSubscriptionErrorDelegate(IntPtr nativeHandle, int status, IntPtr platformError, string subject, IntPtr closure);
 
         /// <summary>
         /// This delegate describes the native function invoked when a sequence number gap is detected. At this
@@ -328,7 +328,7 @@ namespace Wombat
         /// <param name="closure">
         /// The native closure passed to the create function.
         /// </param>
-        protected delegate void OnSubscriptionGapDelegate(IntPtr nativeHandle, IntPtr closure);
+        public delegate void OnSubscriptionGapDelegate(IntPtr nativeHandle, IntPtr closure);
 
         /// <summary>
         /// This delegate describes the native function that is invoked whenever a message arrives.
@@ -346,7 +346,7 @@ namespace Wombat
         /// The item closure for the subscription can be set with setItemClosure, note that setItemClosure is not provided
         /// in the C# implementation.
         /// </param>
-        protected delegate void OnSubscriptionMessageDelegate(IntPtr nativeHandle, IntPtr msg, IntPtr closure, IntPtr itemClosure);
+        public delegate void OnSubscriptionMessageDelegate(IntPtr nativeHandle, IntPtr msg, IntPtr closure, IntPtr itemClosure);
 
         /// <summary>
         /// This delegate describes the native function invoked to indicate a data quality event.
@@ -369,7 +369,7 @@ namespace Wombat
         /// <param name="closure">
         /// The native closure passed to the create function.
         /// </param>
-        protected delegate void OnSubscriptionQualityDelegate(IntPtr nativeHandle, int quality, string symbol, short cause, string platforminfo, IntPtr closure);
+        public delegate void OnSubscriptionQualityDelegate(IntPtr nativeHandle, int quality, string symbol, short cause, string platforminfo, IntPtr closure);
 
         /// <summary>
         /// This delegate describes the native function invoked when a recap is requested upon detecting a
@@ -381,7 +381,7 @@ namespace Wombat
         /// <param name="closure">
         /// The native closure passed to the create function.
         /// </param>
-        protected delegate void OnSubscriptionRecapRequestDelegate(IntPtr nativeHandle, IntPtr closure);
+        public delegate void OnSubscriptionRecapRequestDelegate(IntPtr nativeHandle, IntPtr closure);
 
         #endregion
 

--- a/mama/jni/src/c/mamajni.c
+++ b/mama/jni/src/c/mamajni.c
@@ -335,6 +335,29 @@ JNIEXPORT void JNICALL Java_com_wombat_mama_Mama_start
 
 /*
  * Class:     com_wombat_mama_Mama
+ * Method:    startAll
+ * Signature: (Z)V
+ */
+JNIEXPORT void JNICALL Java_com_wombat_mama_Mama_startAll
+    (JNIEnv* env , jclass class, jboolean isBlocking)
+{
+    mama_status status = MAMA_STATUS_OK;
+    char errorString[UTILS_MAX_ERROR_STRING_LENGTH];
+
+    if (MAMA_STATUS_OK != (status = mama_startAll(isBlocking == JNI_TRUE)))
+    {
+        utils_buildErrorStringForStatus(
+            errorString,
+            UTILS_MAX_ERROR_STRING_LENGTH,
+            "startAll(): Failed to start Mama.",
+            status);
+
+        utils_throwMamaException(env,errorString);
+    }
+}
+
+/*
+ * Class:     com_wombat_mama_Mama
  * Method:    startBackground
  * Signature: (Lcom/wombat/mama/MamaBridge;Lcom/wombat/mama/MamaStartBackgroundCallback;)V
  */
@@ -387,6 +410,29 @@ JNIEXPORT void JNICALL Java_com_wombat_mama_Mama_stop
                             UTILS_MAX_ERROR_STRING_LENGTH,
                             "stop(): Failed to stop Mama.",
                             status);
+
+        utils_throwMamaException(env,errorString);
+    }
+}
+
+/*
+ * Class:     com_wombat_mama_Mama
+ * Method:    stopAll
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_wombat_mama_Mama_stopAll
+    (JNIEnv* env , jclass class)
+{
+    mama_status status = MAMA_STATUS_OK;
+    char errorString[UTILS_MAX_ERROR_STRING_LENGTH];
+
+    if (MAMA_STATUS_OK != (status = mama_stopAll()))
+    {
+        utils_buildErrorStringForStatus(
+            errorString,
+            UTILS_MAX_ERROR_STRING_LENGTH,
+            "stopAll(): Failed to stop Mama.",
+            status);
 
         utils_throwMamaException(env,errorString);
     }

--- a/mama/jni/src/main/java/com/wombat/mama/Mama.java
+++ b/mama/jni/src/main/java/com/wombat/mama/Mama.java
@@ -22,6 +22,8 @@
 package com.wombat.mama;
 
 import java.io.*;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.*;
 import java.net.InetAddress;
 import java.util.Date;
@@ -146,6 +148,24 @@ public class Mama
     public static native void start (MamaBridge bridge);
 
     /**
+     * Calls Mama::start for all currently loaded middleware bridges
+     *
+     * This function is thread safe.
+     *
+     * @param[in] isBlocking Whether to start blocking or run in background
+     */
+     public static native void startAll (boolean isBlocking);
+
+    /**
+     * Calls Mama::start for all currently loaded middleware bridges and blocks.
+     *
+     * This function is thread safe.
+     */
+     public static void startAll () {
+        startAll(true);
+     }
+
+    /**
      * Start processing MAMA internal events in the background. This
      * method invokes Mama::start () in a separate thread.
      *
@@ -167,6 +187,11 @@ public class Mama
      * @param bridge The bridge specific structure.
      */
     public static native void stop (MamaBridge bridge);
+
+    /**
+     * Stop dispatching on the default event queue for all bridges.
+     */
+    public static native void stopAll ();
 
     /**
      * Close MAMA and free all associated resource.

--- a/mamda/java/src/main/java/com/wombat/mamda/orderbook/MamdaOrderBookPriceLevel.java
+++ b/mamda/java/src/main/java/com/wombat/mamda/orderbook/MamdaOrderBookPriceLevel.java
@@ -523,7 +523,7 @@ public class MamdaOrderBookPriceLevel
     /**
      * Update the entry position of an existing entry in the level.
      *
-     * @param entry An instance of <code>MamdaOrderBookEntry</code> with the
+     * @param entryId An instance of <code>MamdaOrderBookEntry</code> with the
      * new details for the entry in the level.
      * @param entryPosition Position of the Entry within the Price Level.
      *
@@ -1248,7 +1248,7 @@ public class MamdaOrderBookPriceLevel
     /**
      * Return the position of an Entry within the Price Level.
      *
-     * @param EntryId  The position of the order book entry.
+     * @param entryId  The position of the order book entry.
      * @return The position of the Entry in the Price Level.
      *         Indexed from 1.
      */


### PR DESCRIPTION
This will start / stop all currently loaded middleware bridges rather than
needing to track MAMA bridge handles within the user's application.

Signed-off-by: Frank Quinn <fquinn@cascadium.io>