### PR TITLE
Added mama_getAllProperties and mama_getAvailableTransportNames

### DIFF
--- a/mama/c_cpp/src/c/mama/mama.h
+++ b/mama/c_cpp/src/c/mama/mama.h
@@ -349,6 +349,20 @@ extern "C"
     mama_getProperty (const char* name);
 
     /**
+     * Build a string containing all configuration properties in the format:
+     *     key1=value
+     *     key2=value
+     *     key3=value
+     *
+     * NB The caller is responsible for destroying memory allocated by this
+     *    function
+     *
+     * @return String representing all the properties
+     */
+    MAMAExpDLL
+    extern const char * mama_getPropertiesAsString (void);
+
+    /**
      * Close MAMA and free all associated resources if no more references exist
      * (e.g.if open has been called 3 times then it will require 3 calls to 
      * close in order for all resources to be freed).
@@ -709,6 +723,19 @@ extern "C"
     extern mama_status
     mama_getPayloadBridge (mamaPayloadBridge *payloadBridge,
                            const char        *payloadName);
+
+    /**
+     *
+     * @param transports
+     * @param count
+     * @param maxCount
+     * @return
+     */
+    MAMAExpDLL
+    extern mama_status
+    mama_getAvailableTransportNames (char transports[][MAMA_MAX_TRANSPORT_LEN],
+                                     size_t maxCount,
+                                     size_t* count);
 
 #if defined(__cplusplus)
 }

--- a/mama/c_cpp/src/cpp/mama/mamacpp.h
+++ b/mama/c_cpp/src/cpp/mama/mamacpp.h
@@ -376,6 +376,13 @@ public:
     static const char * getProperty (const char* name);
 
     /**
+     * Retrieve all configuration properties from the API.
+     *
+     * @return A key value map of all configuration properties
+     */
+    static std::map<std::string, std::string> getProperties ();
+
+    /**
      * Close MAMA and free all associated resource.
      *
      * MAMA employs a reference count to track multiple

--- a/mama/c_cpp/src/cpp/mamacpp.cpp
+++ b/mama/c_cpp/src/cpp/mamacpp.cpp
@@ -230,6 +230,27 @@ namespace Wombat
         return mama_getProperty (name);
     }
 
+    extern "C"
+    {
+        static void mamaImpl_propertyCollectorCb (const char* name,
+                                                  const char* value,
+                                                  void*       closure)
+        {
+            auto* properties =
+                reinterpret_cast<std::map<std::string, std::string>*> (closure);
+            (*properties)[std::string (name)] = std::string (value);
+        }
+    }
+
+    std::map<std::string, std::string> Mama::getProperties ()
+    {
+        std::map<std::string, std::string> properties;
+        properties_ForEach (mamaInternal_getProperties(),
+                            mamaImpl_propertyCollectorCb,
+                            (void*)&properties);
+        return properties;
+    }
+
     void Mama::close ()
     {
         closeCount ();

--- a/mama/c_cpp/src/gunittest/c/CMakeLists.txt
+++ b/mama/c_cpp/src/gunittest/c/CMakeLists.txt
@@ -12,29 +12,8 @@ include_directories(
 	${MAMA_INCLUDES}
 )
 
-macro(UnitTestC bin)
-	add_executable(${bin}
-		${ARGN}
-		MainUnitTestC.cpp
-	)
-	target_link_libraries(${bin} ${GTEST_BOTH_LIBRARIES} mama)
-	install(TARGETS ${bin}
-			RUNTIME DESTINATION bin
-			LIBRARY DESTINATION lib
-			ARCHIVE DESTINATION lib)
-	if (WIN32 AND MSVC)
-		install(FILES $<TARGET_PDB_FILE:${bin}> DESTINATION bin OPTIONAL)
-	endif()
-
-    gtest_discover_tests(
-        ${bin}
-        EXTRA_ARGS -m qpid -p qpidmsg -i Q
-        PROPERTIES ENVIRONMENT
-            "WOMBAT_PATH=${CMAKE_SOURCE_DIR}/mama/c_cpp/src/examples:${CMAKE_SOURCE_DIR}/mama/c_cpp/src/gunittest/c"
-    )
-endmacro()
-
-UnitTestC(UnitTestMamaC
+add_executable(UnitTestMamaC
+	MainUnitTestC.cpp
 	inboxtest.cpp
 	iotest.cpp
 	mamainternaltest.cpp
@@ -53,14 +32,8 @@ UnitTestC(UnitTestMamaC
 	fieldcache/fieldcacheiteratortest.cpp
 	fieldcache/fieldcacherecordtest.cpp
 	fieldcache/fieldcachetest.cpp
-)
-
-UnitTestC(UnitTestMamaDateTimeC
 	mamadatetime/datetimerangetest.cpp
 	mamadatetime/datetimetest.cpp
-)
-
-UnitTestC(UnitTestMamaMsgC
 	mamamsg/msgatomictests.cpp
 	mamamsg/msgcompositetests.cpp
 	mamamsg/msgfieldatomictests.cpp
@@ -70,14 +43,8 @@ UnitTestC(UnitTestMamaMsgC
 	mamamsg/msgiterationtests.cpp
 	mamamsg/msgstatustests.cpp
 	mamamsg/msgvectortests.cpp
-)
-
-UnitTestC(UnitTestMamaPriceC
 	mamaprice/pricegeneraltests.cpp
 	mamaprice/pricerangetests.cpp
-)
-
-UnitTestC(UnitTestMamaMiddlewareC
 	middleware/middlewareGeneralTests.cpp
 	middleware/middlewareInboxTests.cpp
 	middleware/middlewareIoTests.cpp
@@ -87,9 +54,6 @@ UnitTestC(UnitTestMamaMiddlewareC
 	middleware/middlewareSubscriptionTests.cpp
 	middleware/middlewareTimerTests.cpp
 	middleware/middlewareTransportTests.cpp
-)
-
-UnitTestC(UnitTestMamaPayloadC
 	payload/fieldatomictests.cpp
 	payload/fieldcompositetests.cpp
 	payload/fieldvectortests.cpp

--- a/mama/c_cpp/src/gunittest/c/mamainternaltest.cpp
+++ b/mama/c_cpp/src/gunittest/c/mamainternaltest.cpp
@@ -219,6 +219,21 @@ TEST_F (MamaInternalTestC, getProperties)
     ASSERT_EQ (MAMA_STATUS_OK, mama_close ());
 }
 
+TEST_F (MamaInternalTestC, getAllProperties)
+{
+    ASSERT_EQ (MAMA_STATUS_OK, mama_setProperty ("citizen", "kane"));
+    ASSERT_EQ (MAMA_STATUS_OK, mama_setProperty ("busta", "rhymes"));
+    ASSERT_EQ (MAMA_STATUS_OK, mama_setProperty ("taylor", "swift"));
+    ASSERT_EQ (MAMA_STATUS_OK, mama_setProperty ("banana", "rama"));
+    const char* propertiesString = mama_getPropertiesAsString ( );
+    EXPECT_TRUE (NULL != propertiesString);
+
+    EXPECT_TRUE (NULL != strstr (propertiesString, "citizen=kane"));
+    EXPECT_TRUE (NULL != strstr (propertiesString, "busta=rhymes"));
+    EXPECT_TRUE (NULL != strstr (propertiesString, "taylor=swift"));
+    EXPECT_TRUE (NULL != strstr (propertiesString, "banana=rama"));
+}
+
 TEST_F (MamaInternalTestC, getPropertiesUnloaded)
 {
     wproperty_t properties = NULL;

--- a/mama/jni/src/c/mamajni.c
+++ b/mama/jni/src/c/mamajni.c
@@ -991,6 +991,28 @@ JNIEXPORT jstring JNICALL Java_com_wombat_mama_Mama_getProperty
 
 /*
  * Class:     com_wombat_mama_Mama
+ * Method:    getPropertiesAsString
+ * Signature: ()Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_com_wombat_mama_Mama_getPropertiesAsString
+    (JNIEnv* env, jclass class)
+{
+    const char* c_retVal = mama_getPropertiesAsString();
+    if (NULL == c_retVal)
+    {
+        return NULL;
+    }
+    else
+    {
+        jstring result = (*env)->NewStringUTF (env, c_retVal);
+        // This is our memory to free now
+        free ((void*)c_retVal);
+        return result;
+    }
+}
+
+/*
+ * Class:     com_wombat_mama_Mama
  * Method:    getLastErrorCode
  * Signature: ()I
  */

--- a/mama/jni/src/main/java/com/wombat/mama/Mama.java
+++ b/mama/jni/src/main/java/com/wombat/mama/Mama.java
@@ -375,7 +375,52 @@ public class Mama
         }
     }
 
+    /**
+     * Retrieve a specific property from the API.
+     *
+     * If the property has not been set, a NULL value will be returned.
+     *
+     * @param name The name of the property to retrieve.
+     *
+     * @return the value of the property or NULL if unset.
+     */
     public static native String getProperty(String name);
+
+    /**
+     * Retrieve a specific property from the API.
+     *
+     * If the property has not been set, the default value will be returned.
+     *
+     * @param name         The name of the property to retrieve.
+     * @param defaultValue The value to return if this property does not exist.
+     *
+     * @return the value of the property or NULL if unset.
+     */
+    public static String getProperty(String name, String defaultValue) {
+        String property = getProperty(name);
+        if (null == property) {
+            property = defaultValue;
+        }
+        return property;
+    }
+
+    /**
+     * Retrieve a list of all configured properties in key -> value format
+     * @return A map of all currently configured properties
+     */
+    public static Map<String, String> getProperties() {
+        Map<String, String> result = new HashMap<>();
+        String propertiesAsString = getPropertiesAsString();
+        for (String propStringPair : propertiesAsString.split("\n")) {
+            String[] pair = propStringPair.split("=");
+            if (pair.length > 1) {
+                result.put(pair[0], pair[1]);
+            }
+        }
+        return result;
+    }
+
+    private static native String getPropertiesAsString ();
 
     public static native void setProperty (String name, String value);
 


### PR DESCRIPTION
This is to make it easier to find properties matching patterns,
particularly in higher level languages which had no existing option
for doing this.

The mama_getAvailableTransportNames implementation is purely based
on the properties available in currently loaded configuration.

This change includes mama_getPropertiesAsString which will list
all properties in a single allocated string buffer for easy parsing
in higher level languages.

Signed-off-by: Frank Quinn <fquinn@cascadium.io>