### PR TITLE
Added default MAMA subscription callbacks and Basic Wrapper

### DIFF
--- a/mama/c_cpp/src/cpp/mama/MamaBasicSubscription.h
+++ b/mama/c_cpp/src/cpp/mama/MamaBasicSubscription.h
@@ -27,12 +27,15 @@
 namespace Wombat
 {
 class MamaStatus;
+class MamaSubscriptionCallback;
 class MamaMsg;
 class MamaQueue;
-class MamaTransport;
 class MamaBasicSubscriptionCallback;
+class MamaSubscriptionCallbackToMamaBasicSubscriptionCallbackMapper;
+class MamaTransport;
 
 struct MamaBasicSubscriptionImpl;
+
 /**
  * The <code>MamaBasicSubscription</code> interface represents a
  * subscription to a topic with no market data semantics.
@@ -61,8 +64,8 @@ public:
      *
      * @param transport The transport to use. Must be a basic transport.
      * @param queue The queue.
-     * @param callback The mamaMsgCallbacks structure containing the three
-     * callback methods.
+     * @param callback MamaBasicSubscriptionCallback class instance containing
+     *     the three callback methods.
      *
      * @param topic The topic.
      * @param closure The caller supplied closure.
@@ -72,6 +75,26 @@ public:
         MamaTransport*                 transport,
         MamaQueue*                     queue,
         MamaBasicSubscriptionCallback* callback,
+        const char*                    topic,
+        void*                          closure = NULL);
+
+    /**
+      * Create a basic subscription without market data semantics using
+      * MAMA callback structure
+      *
+      * @param transport The transport to use. Must be a basic transport.
+      * @param queue The queue.
+      * @param callback MamaSubscriptionCallback class instance containing
+      *     the three callback methods.
+      *
+      * @param topic The topic.
+      * @param closure The caller supplied closure.
+      *
+     */
+    virtual void createBasic (
+        MamaTransport*                 transport,
+        MamaQueue*                     queue,
+        MamaSubscriptionCallback*      callback,
         const char*                    topic,
         void*                          closure = NULL);
 
@@ -188,6 +211,8 @@ private:
     MamaBasicSubscriptionCallback *mCallback;
 
     MamaBasicSubscriptionImpl*     mImpl;
+
+    MamaSubscriptionCallbackToMamaBasicSubscriptionCallbackMapper* mCallbackMapper;
 protected:
 
     // The closure passed to the create function

--- a/mama/c_cpp/src/cpp/mama/MamaBasicSubscriptionCallback.h
+++ b/mama/c_cpp/src/cpp/mama/MamaBasicSubscriptionCallback.h
@@ -37,6 +37,8 @@ namespace Wombat
  * @see MamaSubscription
  * @author mls
  */
+class MamaBasicSubscription;
+
 class MAMACPPExpDLL MamaBasicSubscriptionCallback
 {
 public:

--- a/mama/c_cpp/src/cpp/mama/MamaBasicWildCardSubscriptionCallback.h
+++ b/mama/c_cpp/src/cpp/mama/MamaBasicWildCardSubscriptionCallback.h
@@ -23,10 +23,10 @@
 #define MAMA_BASIC_WILD_CARD_SUBSCRIPTION_CALLBACK_CPP_H__
 
 #include "mama/mamacpp.h"
-#include "mama/MamaBasicWildCardSubscription.h"
 
-namespace Wombat 
+namespace Wombat
 {
+class MamaBasicWildCardSubscription;
 /**
  * The message callback interface for basic subscriptions. 
  * Callers provide an object implementing this 

--- a/mama/c_cpp/src/cpp/mama/MamaSubscriptionCallback.h
+++ b/mama/c_cpp/src/cpp/mama/MamaSubscriptionCallback.h
@@ -53,7 +53,8 @@ namespace Wombat
          *
          * @param subscription The subscription.
          */
-        virtual void onCreate (MamaSubscription*  subscription) = 0;
+        virtual void onCreate (MamaSubscription*  subscription)
+        {};
 
         /**
          * Invoked if an error occurs during prior to subscription
@@ -71,7 +72,13 @@ namespace Wombat
          */
         virtual void onError (MamaSubscription*  subscription,
                               const MamaStatus&  status,
-                              const char*        symbol) = 0;
+                              const char*        symbol)
+        {
+            mama_log (MAMA_LOG_LEVEL_ERROR,
+                      "Found error %s while trying to subscribe to '%s'",
+                      status.toString(),
+                      symbol != nullptr ? symbol : "(null)");
+        };
 
         /**
          * Method invoked when a sequence number gap is detected. At this
@@ -132,7 +139,8 @@ namespace Wombat
                                 mamaQuality        quality,
                                 const char*        symbol,
                                 short              cause,
-                                const void*        platformInfo) = 0;
+                                const void*        platformInfo)
+        {};
        
         /* By default forward to MamaSubscription callback */
         virtual void onCreate (MamaBasicSubscription*  subscription)


### PR DESCRIPTION
Added default implementations for gap, recap etc which will log
when they are received and high level details.

Also added subscription wrapper for MamaBasicSubscription in C++
which will allow the caller to use standard MamaSubscriptionCallback
rather than having to use separate basic subscription callbacks.

Also onCreate, onQuality and onError is no longer mandatory for
MAMA C++.

Signed-off-by: Frank Quinn <fquinn@cascadium.io>