### PR TITLE
Added MamaQueueGroup.getQueueGroupByIndex for C++, C# and Java

### DIFF
--- a/mama/c_cpp/src/cpp/MamaQueueGroup.cpp
+++ b/mama/c_cpp/src/cpp/MamaQueueGroup.cpp
@@ -82,6 +82,11 @@ namespace Wombat
                                 : mQueues [mCallCount++ % mQueueCount];
     }
 
+    MamaQueue* MamaQueueGroup::getQueueByIndex (int index)
+    {
+        return mQueues == nullptr ? nullptr : mQueues [index % mQueueCount];
+    }
+
     int MamaQueueGroup::getNumberOfQueues (void)
     {
         return mQueueCount;

--- a/mama/c_cpp/src/cpp/MamaSubscription.cpp
+++ b/mama/c_cpp/src/cpp/MamaSubscription.cpp
@@ -564,6 +564,7 @@ namespace Wombat
         // Save the callback in the member variable
         mCallback = callback;
         mClosure  = closure;
+        mTransport = source->getTransport();
 
         // Save the queue so that calls to MamaBasicSubscription->getQueue () work
         mQueue = queue;

--- a/mama/c_cpp/src/cpp/mama/MamaQueueGroup.h
+++ b/mama/c_cpp/src/cpp/mama/MamaQueueGroup.h
@@ -59,6 +59,13 @@ namespace Wombat
         virtual MamaQueue* getNextQueue ();
 
         /**
+         * Return the requested Queue based on the given index, or NULL if it
+         * is not a valid index.
+         * @return pointer to queue object
+         */
+        MamaQueue* getQueueByIndex (int index);
+
+        /**
          * Return the number of MamaQueues currently managed by this queue group.
          */
         virtual int getNumberOfQueues ();

--- a/mama/dotnet/src/cs/MamaQueueGroup.cs
+++ b/mama/dotnet/src/cs/MamaQueueGroup.cs
@@ -441,6 +441,27 @@ namespace Wombat
             return ret;
         }
 
+		/// <summary>
+		/// This function will return the queue in this queue group at the given index specifically.
+		/// </summary>
+        public MamaQueue getQueueByIndex(int index)
+        {
+            // Returns
+            MamaQueue ret = null;
+
+            lock(this)
+            {
+                // Only continue if the array of threads is valid
+                if (mQueueThreads != null)
+                {
+                    // Get the queue at this index and increment.
+                    ret = mQueueThreads[index % mQueueThreads.Length].Queue;
+                }
+            }
+
+            return ret;
+        }
+
         #endregion
     }
 

--- a/mama/jni/src/main/java/com/wombat/mama/MamaQueueGroup.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaQueueGroup.java
@@ -133,6 +133,17 @@ public class MamaQueueGroup
                                 : myQueues[myCurQueue++ % myQueues.length];
     }
 
+    /**
+     * Return the requested Queue based on the given index, or null if it
+     * is not a valid index.
+     *
+     * @return The queue object
+     */
+    public MamaQueue getQueueByIndex(int index)
+    {
+        return myQueues == null ? Mama.getDefaultQueue (myBridge) : myQueues[index % myQueues.length];
+    }
+
 
     public void stopDispatch ()
     {

--- a/mama/jni/src/main/java/com/wombat/mama/MamaSubscription.java
+++ b/mama/jni/src/main/java/com/wombat/mama/MamaSubscription.java
@@ -63,6 +63,8 @@ public class MamaSubscription
     /* The type of the subscription. */
     private MamaSubscriptionType mySubType = MamaSubscriptionType.NORMAL;
 
+    private MamaQueue mQueue = null;
+
     /* ************************************************** */
     /* Construction and Finalization. */
     /* ************************************************** */
@@ -127,6 +129,9 @@ public class MamaSubscription
         // Save the closure as well
         myClosure = closure;
 
+        // Save the queue
+        mQueue = queue;
+
         // Create the native subscription
         createNativeSubscription(
             callback,
@@ -151,6 +156,9 @@ public class MamaSubscription
         MamaQueue               queue,
         MamaSource              source)
     {
+        // Save the queue
+        mQueue = queue;
+
         // Simply call the overload
         return createDictionarySubscription (
                 callback,
@@ -179,6 +187,9 @@ public class MamaSubscription
     {
         // Save the source to prevent additional context switches into C
         mySource = source;
+
+        // Save the queue
+        mQueue = queue;
 
         // Create the native dictionary subscription
         return createNativeDictionarySubscription(callback, queue, source, timeout, retries);
@@ -214,6 +225,9 @@ public class MamaSubscription
 
         // Save the closure
         myClosure = closure;
+
+        // Save the queue
+        mQueue = queue;
 
         // Create the native subscription
         createNativeSubscription(
@@ -252,6 +266,15 @@ public class MamaSubscription
     public MamaSource getSource ()
     {
         return mySource;
+    }
+
+    /**
+     * Return the queue used for this subscription
+     *
+     * @return The MamaQueue object
+     */
+    public MamaQueue getQueue () {
+        return mQueue;
     }
 
     /**
@@ -294,6 +317,9 @@ public class MamaSubscription
 
         // Save the closure
         myClosure = closure;
+
+        // Save the queue
+        mQueue = queue;
 
         // Create the native subscription
         setupNativeSubscription(


### PR DESCRIPTION
This will return a specific queue group within the group based
on a numerical index.

Also added MamaSubscription.getQueue for Java since it was missing.

Signed-off-by: Frank Quinn <fquinn@cascadium.io>