### PR TITLE
fix for bad cast

### DIFF
--- a/mama/c_cpp/src/c/transport.c
+++ b/mama/c_cpp/src/c/transport.c
@@ -936,7 +936,7 @@ mamaTransport_create (mamaTransport transport,
     }
 
 
-    if (strlen((char*)gEntitlementBridges))   /* If entitlement bridges were built in at compile time. */
+    if (gEntitlementBridges[0])   /* If entitlement bridges were built in at compile time. */
     {
         snprintf (propNameBuf, sizeof(propNameBuf), "mama.transport.%s.entitlementBridge", self->mName);
         propValue = properties_Get (mamaInternal_getProperties (), propNameBuf);


### PR DESCRIPTION
There appears to be a Heisenbug lurking in Mama that can cause intermittent failure in the unit tests (specifically `MamaSubscriptionTest.SubscriptionCreateDestroy` in `UnitTestMamaC`) and by extension in any code using subscriptions (which is pretty much all Mama applications).  The bug causes `mamaSubscription_create` to fail with the error "mamaSubscription_setupBasic(): Could not find entitlement bridge!".

So far I've only seen this in one specific environment: CentOS 7 with clang 10.0.1 and Address Sanitizer.  The same test runs fine with clang without ASAN, with gcc, and with all the above on Ubuntu 20.04.

Here's the bug (from `src/mama/c_cpp/src/c/transport.c:940`):

``` 
    if (strlen((char*)gEntitlementBridges))   /* If entitlement bridges were built in at compile time. */
```

The correct code is:

```
    if (gEntitlementBridges[0])   /* If entitlement bridges were built in at compile time. */
```

The original code fails if `gEntitlementBridges ` is allocated on a 256-byte boundary, such that the low-order byte of its address is zero.  

As far as reproducing the problem and verifying the fix goes, that's a problem -- the triggering condition appears to happen rarely, and depends on how Mama is built.  (However, once a particular build fails, it appears to fail consistently).

In addition, merely moving things around (e.g., adding a log statement prior to the offending code), can avoid triggering the problem.

