### PR TITLE
Several fixes to improve packaging and experience

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.16)
 project (OpenMAMA)
 
 set (CMAKE_CXX_STANDARD 11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,16 +202,16 @@ install(
 
 install(
     EXPORT OpenMAMA-targets
-    DESTINATION share/OpenMAMA
+    DESTINATION lib/cmake/OpenMAMA
     NAMESPACE OpenMAMA::
 )
 
 configure_package_config_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/OpenMAMAConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/OpenMAMAConfig.cmake
-    INSTALL_DESTINATION share/OpenMAMA)
+    INSTALL_DESTINATION lib/cmake/OpenMAMA)
 
 install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenMAMAConfig.cmake
-    DESTINATION "share/OpenMAMA"
+    DESTINATION lib/cmake/OpenMAMA
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,3 +180,37 @@ install(FILES LICENSE.md DESTINATION .)
 install(FILES mama/c_cpp/src/examples/mama.properties DESTINATION config)
 
 include(CPack)
+
+include(CMakePackageConfigHelpers)
+
+set(OPENMAMA_INSTALL_TARGETS wombatcommon mama mamabaseimpl)
+if (WITH_CPP)
+    list(APPEND OPENMAMA_INSTALL_TARGETS wombatcommoncpp mamacpp)
+endif()
+if (WITH_MAMDA)
+    list(APPEND OPENMAMA_INSTALL_TARGETS mamda mamdanews mamdaoptions mamdabook)
+    set(OPENMAMA_INSTALL_TARGETS ${OPENMAMA_INSTALL_TARGETS}  )
+endif()
+install(
+    TARGETS ${OPENMAMA_INSTALL_TARGETS}
+    EXPORT OpenMAMA-targets
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin
+)
+
+install(
+    EXPORT OpenMAMA-targets
+    DESTINATION share/OpenMAMA
+    NAMESPACE OpenMAMA::
+)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/OpenMAMAConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/OpenMAMAConfig.cmake
+    INSTALL_DESTINATION share/OpenMAMA)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenMAMAConfig.cmake
+    DESTINATION "share/OpenMAMA"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ install(
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include
 )
 
 install(

--- a/cmake/OpenMAMAConfig.cmake.in
+++ b/cmake/OpenMAMAConfig.cmake.in
@@ -1,0 +1,1 @@
+@PACKAGE_INIT@

--- a/cmake/OpenMAMAConfig.cmake.in
+++ b/cmake/OpenMAMAConfig.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/OpenMAMA-Targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/OpenMAMA-targets.cmake")
 
 set (OpenMAMA_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include)
 set (OpenMAMA_LIBRARIES OpenMAMA::mama OpenMAMA::wombatcommon)

--- a/cmake/OpenMAMAConfig.cmake.in
+++ b/cmake/OpenMAMAConfig.cmake.in
@@ -5,3 +5,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/OpenMAMA-Targets.cmake")
 set (OpenMAMA_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include)
 set (OpenMAMA_LIBRARIES OpenMAMA::mama OpenMAMA::wombatcommon)
 set (OpenMAMA_FOUND True)
+
+check_required_components(OpenMAMA)

--- a/cmake/OpenMAMAConfig.cmake.in
+++ b/cmake/OpenMAMAConfig.cmake.in
@@ -1,1 +1,7 @@
 @PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/OpenMAMA-Targets.cmake")
+
+set (OpenMAMA_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include)
+set (OpenMAMA_LIBRARIES OpenMAMA::mama OpenMAMA::wombatcommon)
+set (OpenMAMA_FOUND True)

--- a/common/c_cpp/src/c/CMakeLists.txt
+++ b/common/c_cpp/src/c/CMakeLists.txt
@@ -56,9 +56,9 @@ install(FILES ${wombat_inst_includes}
 	DESTINATION include/wombat)
 
 if(WIN32)
-    file(GLOB wombat_platform_inst_includes ${system}/*.h)
+    file(GLOB wombat_platform_inst_includes wombat/windows/*.h)
     install(FILES ${wombat_platform_inst_includes}
-        DESTINATION include/wombat/${system})
+        DESTINATION include/wombat/windows)
 endif()
 
 if (WIN32 AND MSVC)

--- a/devops/build/ci-run.sh
+++ b/devops/build/ci-run.sh
@@ -145,7 +145,7 @@ fpm -s dir --force \
         $DEPENDS_FLAGS \
         -p "$PACKAGE_FILE" \
         --description "OpenMAMA high performance Market Data API" \
-        $OPENMAMA_INSTALL_DIR/=/usr/
+        $OPENMAMA_INSTALL_DIR/=/opt/openmama/
 
 find "$DIST_DIR" -type f -name "*.$PACKAGE_TYPE"
 

--- a/devops/build/ci-run.sh
+++ b/devops/build/ci-run.sh
@@ -95,7 +95,7 @@ fi
 if [ -f /etc/redhat-release ]
 then
     DISTRIB_RELEASE=$(cat /etc/redhat-release | tr " " "\n" | egrep "^[0-9]")
-    DEPENDS_FLAGS="-d libuuid -d libevent -d ncurses -d apr -d java-11-openjdk"
+    DEPENDS_FLAGS="-d libuuid -d libevent -d ncurses -d apr -d apr-util -d java-11-openjdk"
     DISTRIB_ID=$RHEL
     PACKAGE_TYPE=rpm
     CLOUDSMITH_DISTRO_NAME=centos
@@ -112,7 +112,7 @@ then
     # Will set DISTRIB_ID and DISTRIB_RELEASE
     source /etc/lsb-release
     PACKAGE_TYPE=deb
-    DEPENDS_FLAGS="-d uuid -d libevent-dev -d libzmq3-dev -d ncurses-dev -d libapr1-dev -d openjdk-11-jdk"
+    DEPENDS_FLAGS="-d uuid -d libevent-dev -d libzmq3-dev -d ncurses-dev -d libapr1-dev -d libaprutil1-dev -d openjdk-11-jdk"
     CLOUDSMITH_DISTRO_NAME=ubuntu
     CLOUDSMITH_DISTRO_VERSION=${DISTRIB_CODENAME}
 fi

--- a/devops/build/ci-run.sh
+++ b/devops/build/ci-run.sh
@@ -145,7 +145,7 @@ fpm -s dir --force \
         $DEPENDS_FLAGS \
         -p "$PACKAGE_FILE" \
         --description "OpenMAMA high performance Market Data API" \
-        $OPENMAMA_INSTALL_DIR/=/opt/openmama/
+        $OPENMAMA_INSTALL_DIR/=/usr/
 
 find "$DIST_DIR" -type f -name "*.$PACKAGE_TYPE"
 

--- a/devops/build/install-dependencies.sh
+++ b/devops/build/install-dependencies.sh
@@ -91,6 +91,11 @@ then
 	    apt-transport-https ca-certificates libaprutil1-dev
     apt-get install -y rubygems openjdk-11-jdk
     echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64" > /etc/profile.d/profile.jni.sh
+    if [ "${DISTRIB_RELEASE:0:2}" = "18" ]
+    then
+        # Ubuntu 18 cmake version is too old - upgrade it
+        (cd /usr && wget -c https://github.com/Kitware/CMake/releases/download/v3.19.4/cmake-3.19.4-Linux-x86_64.tar.gz -O - | tar -xz  --strip-components 1)
+    fi
 fi
 
 # RHEL 7 ruby is too old - need a more recent version for FPM to work later

--- a/devops/build/install-dependencies.sh
+++ b/devops/build/install-dependencies.sh
@@ -99,8 +99,9 @@ then
 fi
 
 # RHEL 7 ruby is too old - need a more recent version for FPM to work later
-if [[ ("$DISTRIB_ID" = "$RHEL" && "${DISTRIB_RELEASE:0:1}" -le "7") ]]
+if [[ ("$DISTRIB_ID" = "$UBUNTU" && "${DISTRIB_RELEASE:0:2}" -le "18") || ("$DISTRIB_ID" = "$RHEL" && "${DISTRIB_RELEASE:0:1}" -le "7") ]]
 then
+    apt-get install -y libssl-ocaml-dev
     cd "$DEPS_DIR"
     curl -sL "https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.1.tar.gz" | tar xz
     cd ruby-2.6.1

--- a/tutorials/c/01-quickstart/CMakeLists.txt
+++ b/tutorials/c/01-quickstart/CMakeLists.txt
@@ -4,4 +4,4 @@ project ("01-quickstart")
 find_package(OpenMAMA REQUIRED)
 
 add_executable(quickstartc quickstart.c)
-target_link_libraries(quickstartc PRIVATE OpenMAMA::wombatcommon OpenMAMA::mama OpenMAMA::mamacpp)
+target_link_libraries(quickstartc PRIVATE OpenMAMA::mama)

--- a/tutorials/c/01-quickstart/CMakeLists.txt
+++ b/tutorials/c/01-quickstart/CMakeLists.txt
@@ -1,16 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
 project ("01-quickstart")
 
-if (DEFINED ENV{OPENMAMA_ROOT})
-  set (OPENMAMA_ROOT_DEFAULT $ENV{OPENMAMA_ROOT})
-else ()
-  set (OPENMAMA_ROOT_DEFAULT "/opt/openmama")
-endif ()
-
-set (OPENMAMA_ROOT ${OPENMAMA_ROOT_DEFAULT} CACHE PATH "Location of the OpenMAMA installation to use")
-
-include_directories(${OPENMAMA_ROOT}/include)
-link_directories(${OPENMAMA_ROOT}/lib)
+find_package(OpenMAMA REQUIRED)
 
 add_executable(quickstartc quickstart.c)
-target_link_libraries(quickstartc mama wombatcommon)
+target_link_libraries(quickstartc PRIVATE OpenMAMA::wombatcommon OpenMAMA::mama OpenMAMA::mamacpp)

--- a/tutorials/c/01-quickstart/quickstart.c
+++ b/tutorials/c/01-quickstart/quickstart.c
@@ -143,39 +143,54 @@ int main(int argc, char* argv[])
     int requiresInitial = 1;
 
     // Parse out command line options
-    int opt;
-    while((opt = getopt(argc, argv, ":Bd:Im:s:S:t:v")) != -1) {
-        switch(opt) {
-            case 'B':
-                requiresDictionary = 0;
-                break;
-            case 'd':
-                dictionaryFile = optarg;
-                break;
-            case 'I':
-                requiresInitial = 0;
-                break;
-            case 'm':
-                middlewareName = optarg;
-                break;
-            case 's':
-                symbolName = optarg;
-                break;
-            case 'S':
-                sourceName = optarg;
-                break;
-            case 't':
-                transportName = optarg;
-                break;
-            case 'v':
-                // Set up the Log level for OpenMAMA internals
-                mama_setLogLevel(MAMA_LOG_LEVEL_FINEST);
-                break;
-            default:
-                fprintf(stderr, "Encountered '%c'\n\n", optopt);
-                usageAndExit(argv[0]);
-                break;
+    int i = 0;
+    for (i = 1; i < argc; )
+    {
+        if (strcmp ("-B", argv[i]) == 0)
+        {
+            requiresDictionary = 0;
         }
+        else if (strcmp ("-d", argv[i]) == 0)
+        {
+            dictionaryFile = argv[++i];
+        }
+        else if (strcmp ("-I", argv[i]) == 0)
+        {
+            requiresInitial = 0;
+        }
+        else if (strcmp ("-m", argv[i]) == 0)
+        {
+            middlewareName = argv[++i];
+        }
+        else if (strcmp ("-s", argv[i]) == 0)
+        {
+            symbolName = argv[++i];
+        }
+        else if (strcmp ("-S", argv[i]) == 0)
+        {
+            sourceName = argv[++i];
+        }
+        else if (strcmp ("-t", argv[i]) == 0)
+        {
+            transportName = argv[++i];
+        }
+        else if (strcmp ("-v", argv[i]) == 0)
+        {
+            // Set up the Log level for OpenMAMA internals
+            mama_setLogLevel(MAMA_LOG_LEVEL_FINEST);
+        }
+        else if ((strcmp (argv[i], "-h") == 0)||
+                 (strcmp (argv[i], "--help") == 0)||
+                 (strcmp (argv[i], "-?") == 0))
+        {
+            usageAndExit(argv[0]);
+        }
+        else
+        {
+            fprintf(stderr, "Unknown arg: %s\n",    argv[i]);
+            usageAndExit(argv[0]);
+        }
+        ++i;
     }
 
     // Symbol name is mandatory here, so error if it's NULL

--- a/tutorials/c/02-resourcepool/CMakeLists.txt
+++ b/tutorials/c/02-resourcepool/CMakeLists.txt
@@ -1,18 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
 project ("02-resourcepool")
 
-if (DEFINED ENV{OPENMAMA_ROOT})
-  set (OPENMAMA_ROOT_DEFAULT $ENV{OPENMAMA_ROOT})
-else ()
-  set (OPENMAMA_ROOT_DEFAULT "/opt/openmama")
-endif ()
-
-set (OPENMAMA_ROOT ${OPENMAMA_ROOT_DEFAULT} CACHE PATH "Location of the OpenMAMA installation to use")
-
-include_directories(${CMAKE_SOURCE_DIR}/mama/c_cpp/src/c)
-include_directories(${CMAKE_SOURCE_DIR}/common/c_cpp/src/c)
-include_directories(${OPENMAMA_ROOT}/include)
-link_directories(${OPENMAMA_ROOT}/lib)
+find_package(OpenMAMA REQUIRED)
 
 add_executable(resourcepoolc resourcepool.c)
-target_link_libraries(resourcepoolc mama wombatcommon)
+target_link_libraries(resourcepoolc PRIVATE OpenMAMA::wombatcommon OpenMAMA::mama OpenMAMA::mamacpp)

--- a/tutorials/c/02-resourcepool/CMakeLists.txt
+++ b/tutorials/c/02-resourcepool/CMakeLists.txt
@@ -4,4 +4,4 @@ project ("02-resourcepool")
 find_package(OpenMAMA REQUIRED)
 
 add_executable(resourcepoolc resourcepool.c)
-target_link_libraries(resourcepoolc PRIVATE OpenMAMA::wombatcommon OpenMAMA::mama OpenMAMA::mamacpp)
+target_link_libraries(resourcepoolc PRIVATE OpenMAMA::mama)

--- a/tutorials/c/02-resourcepool/resourcepool.c
+++ b/tutorials/c/02-resourcepool/resourcepool.c
@@ -59,39 +59,54 @@ int main(int argc, char* argv[])
     int requiresInitial = 1;
 
     // Parse out command line options
-    int opt;
-    while((opt = getopt(argc, argv, ":Bd:Is:S:t:u:v")) != -1) {
-        switch(opt) {
-        case 'B':
+    int i = 0;
+    for (i = 1; i < argc; )
+    {
+        if (strcmp ("-B", argv[i]) == 0)
+        {
             requiresDictionary = 0;
-            break;
-        case 'd':
-            dictionaryFile = optarg;
-            break;
-        case 'I':
+        }
+        else if (strcmp ("-d", argv[i]) == 0)
+        {
+            dictionaryFile = argv[++i];
+        }
+        else if (strcmp ("-I", argv[i]) == 0)
+        {
             requiresInitial = 0;
-            break;
-        case 's':
-            symbolName = optarg;
-            break;
-        case 'S':
-            sourceName = optarg;
-            break;
-        case 't':
-            transportName = optarg;
-            break;
-        case 'u':
-            uri = optarg;
-            break;
-        case 'v':
+        }
+        else if (strcmp ("-s", argv[i]) == 0)
+        {
+            symbolName = argv[++i];
+        }
+        else if (strcmp ("-S", argv[i]) == 0)
+        {
+            sourceName = argv[++i];
+        }
+        else if (strcmp ("-t", argv[i]) == 0)
+        {
+            transportName = argv[++i];
+        }
+        else if (strcmp ("-u", argv[i]) == 0)
+        {
+            uri = argv[++i];
+        }
+        else if (strcmp ("-v", argv[i]) == 0)
+        {
             // Set up the Log level for OpenMAMA internals
             mama_setLogLevel(MAMA_LOG_LEVEL_FINEST);
-            break;
-        default:
-            fprintf(stderr, "Encountered '%c'\n\n", optopt);
-            usageAndExit(argv[0]);
-            break;
         }
+        else if ((strcmp (argv[i], "-h") == 0)||
+                 (strcmp (argv[i], "--help") == 0)||
+                 (strcmp (argv[i], "-?") == 0))
+        {
+            usageAndExit(argv[0]);
+        }
+        else
+        {
+            fprintf(stderr, "Unknown arg: %s\n",    argv[i]);
+            usageAndExit(argv[0]);
+        }
+        ++i;
     }
 
     // Set up the data dictionary

--- a/tutorials/cpp/01-quickstart/CMakeLists.txt
+++ b/tutorials/cpp/01-quickstart/CMakeLists.txt
@@ -4,4 +4,4 @@ project ("01-quickstart")
 find_package(OpenMAMA REQUIRED)
 
 add_executable(quickstartcpp quickstart.cpp)
-target_link_libraries(quickstartcpp PRIVATE OpenMAMA::wombatcommon OpenMAMA::mama OpenMAMA::mamacpp)
+target_link_libraries(quickstartcpp PRIVATE OpenMAMA::mamacpp)

--- a/tutorials/cpp/01-quickstart/CMakeLists.txt
+++ b/tutorials/cpp/01-quickstart/CMakeLists.txt
@@ -1,19 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
 project ("01-quickstart")
 
-if (DEFINED ENV{OPENMAMA_ROOT})
-  set (OPENMAMA_ROOT_DEFAULT $ENV{OPENMAMA_ROOT})
-else ()
-  set (OPENMAMA_ROOT_DEFAULT "/opt/openmama")
-endif ()
-
-set (OPENMAMA_ROOT ${OPENMAMA_ROOT_DEFAULT} CACHE PATH "Location of the OpenMAMA installation to use")
-
-include_directories(${CMAKE_SOURCE_DIR}/mama/c_cpp/src/c)
-include_directories(${CMAKE_SOURCE_DIR}/mama/c_cpp/src/cpp)
-include_directories(${CMAKE_SOURCE_DIR}/common/c_cpp/src/c)
-include_directories(${OPENMAMA_ROOT}/include)
-link_directories(${OPENMAMA_ROOT}/lib)
+find_package(OpenMAMA REQUIRED)
 
 add_executable(quickstartcpp quickstart.cpp)
-target_link_libraries(quickstartcpp mamacpp wombatcommon)
+target_link_libraries(quickstartcpp PRIVATE OpenMAMA::wombatcommon OpenMAMA::mama OpenMAMA::mamacpp)

--- a/tutorials/cpp/01-quickstart/quickstart.cpp
+++ b/tutorials/cpp/01-quickstart/quickstart.cpp
@@ -105,9 +105,6 @@ public:
 
 int main(int argc, char* argv[])
 {
-    // OpenMAMA status variable which we will use throughout this example
-    mama_status status;
-
     // Parse the command line options to override defaults
     const char* middlewareName = "qpid";
     const char* transportName = "sub";
@@ -118,39 +115,54 @@ int main(int argc, char* argv[])
     bool requiresInitial = true;
 
     // Parse out command line options
-    int opt;
-    while((opt = getopt(argc, argv, ":Bd:Im:s:S:t:v")) != -1) {
-        switch(opt) {
-            case 'B':
-                requiresDictionary = false;
-                break;
-            case 'd':
-                dictionaryFile = optarg;
-                break;
-            case 'I':
-                requiresInitial = false;
-                break;
-            case 'm':
-                middlewareName = optarg;
-                break;
-            case 's':
-                symbolName = optarg;
-                break;
-            case 'S':
-                sourceName = optarg;
-                break;
-            case 't':
-                transportName = optarg;
-                break;
-            case 'v':
-                // Set up the Log level for OpenMAMA internals
-                Mama::setLogLevel(MAMA_LOG_LEVEL_FINEST);
-                break;
-            default:
-                fprintf(stderr, "Encountered '%c'\n\n", optopt);
-                usageAndExit(argv[0]);
-                break;
+    int i = 0;
+    for (i = 1; i < argc; )
+    {
+        if (strcmp ("-B", argv[i]) == 0)
+        {
+            requiresDictionary = 0;
         }
+        else if (strcmp ("-d", argv[i]) == 0)
+        {
+            dictionaryFile = argv[++i];
+        }
+        else if (strcmp ("-I", argv[i]) == 0)
+        {
+            requiresInitial = 0;
+        }
+        else if (strcmp ("-m", argv[i]) == 0)
+        {
+            middlewareName = argv[++i];
+        }
+        else if (strcmp ("-s", argv[i]) == 0)
+        {
+            symbolName = argv[++i];
+        }
+        else if (strcmp ("-S", argv[i]) == 0)
+        {
+            sourceName = argv[++i];
+        }
+        else if (strcmp ("-t", argv[i]) == 0)
+        {
+            transportName = argv[++i];
+        }
+        else if (strcmp ("-v", argv[i]) == 0)
+        {
+            // Set up the Log level for OpenMAMA internals
+            Mama::setLogLevel(MAMA_LOG_LEVEL_FINEST);
+        }
+        else if ((strcmp (argv[i], "-h") == 0)||
+                 (strcmp (argv[i], "--help") == 0)||
+                 (strcmp (argv[i], "-?") == 0))
+        {
+            usageAndExit(argv[0]);
+        }
+        else
+        {
+            fprintf(stderr, "Unknown arg: %s\n",    argv[i]);
+            usageAndExit(argv[0]);
+        }
+        ++i;
     }
 
     // Symbol name is mandatory here, so error if it's NULL

--- a/tutorials/cpp/02-resourcepool/CMakeLists.txt
+++ b/tutorials/cpp/02-resourcepool/CMakeLists.txt
@@ -4,4 +4,4 @@ project ("02-resourcepool")
 find_package(OpenMAMA REQUIRED)
 
 add_executable(resourcepoolcpp resourcepool.cpp)
-target_link_libraries(resourcepoolcpp PRIVATE OpenMAMA::wombatcommon OpenMAMA::mama OpenMAMA::mamacpp)
+target_link_libraries(resourcepoolcpp PRIVATE OpenMAMA::mamacpp)

--- a/tutorials/cpp/02-resourcepool/CMakeLists.txt
+++ b/tutorials/cpp/02-resourcepool/CMakeLists.txt
@@ -1,19 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
 project ("02-resourcepool")
 
-if (DEFINED ENV{OPENMAMA_ROOT})
-  set (OPENMAMA_ROOT_DEFAULT $ENV{OPENMAMA_ROOT})
-else ()
-  set (OPENMAMA_ROOT_DEFAULT "/opt/openmama")
-endif ()
-
-set (OPENMAMA_ROOT ${OPENMAMA_ROOT_DEFAULT} CACHE PATH "Location of the OpenMAMA installation to use")
-
-include_directories(${CMAKE_SOURCE_DIR}/mama/c_cpp/src/c)
-include_directories(${CMAKE_SOURCE_DIR}/mama/c_cpp/src/cpp)
-include_directories(${CMAKE_SOURCE_DIR}/common/c_cpp/src/c)
-include_directories(${OPENMAMA_ROOT}/include)
-link_directories(${OPENMAMA_ROOT}/lib)
+find_package(OpenMAMA REQUIRED)
 
 add_executable(resourcepoolcpp resourcepool.cpp)
-target_link_libraries(resourcepoolcpp mama mamacpp wombatcommon)
+target_link_libraries(resourcepoolcpp PRIVATE OpenMAMA::wombatcommon OpenMAMA::mama OpenMAMA::mamacpp)

--- a/tutorials/cpp/02-resourcepool/resourcepool.cpp
+++ b/tutorials/cpp/02-resourcepool/resourcepool.cpp
@@ -40,7 +40,6 @@ void usageAndExit(const char* appName) {
 int main(int argc, char* argv[])
 {
     // OpenMAMA status variable which we will use throughout this example
-    mama_status status;
     const char* transportName = "sub";
     const char* sourceName = "OM";
     const char* symbolName = NULL;
@@ -50,39 +49,54 @@ int main(int argc, char* argv[])
     int requiresInitial = 1;
 
     // Parse out command line options
-    int opt;
-    while((opt = getopt(argc, argv, ":Bd:Im:s:S:t:u:v")) != -1) {
-        switch(opt) {
-            case 'B':
-                requiresDictionary = false;
-                break;
-            case 'd':
-                dictionaryFile = optarg;
-                break;
-            case 'I':
-                requiresInitial = false;
-                break;
-            case 's':
-                symbolName = optarg;
-                break;
-            case 'S':
-                sourceName = optarg;
-                break;
-            case 't':
-                transportName = optarg;
-                break;
-            case 'u':
-                uri = optarg;
-                break;
-            case 'v':
-                // Set up the Log level for OpenMAMA internals
-                Mama::setLogLevel(MAMA_LOG_LEVEL_FINEST);
-                break;
-            default:
-                fprintf(stderr, "Encountered '%c'\n\n", optopt);
-                usageAndExit(argv[0]);
-                break;
+    int i = 0;
+    for (i = 1; i < argc; )
+    {
+        if (strcmp ("-B", argv[i]) == 0)
+        {
+            requiresDictionary = 0;
         }
+        else if (strcmp ("-d", argv[i]) == 0)
+        {
+            dictionaryFile = argv[++i];
+        }
+        else if (strcmp ("-I", argv[i]) == 0)
+        {
+            requiresInitial = 0;
+        }
+        else if (strcmp ("-s", argv[i]) == 0)
+        {
+            symbolName = argv[++i];
+        }
+        else if (strcmp ("-S", argv[i]) == 0)
+        {
+            sourceName = argv[++i];
+        }
+        else if (strcmp ("-t", argv[i]) == 0)
+        {
+            transportName = argv[++i];
+        }
+        else if (strcmp ("-u", argv[i]) == 0)
+        {
+            uri = argv[++i];
+        }
+        else if (strcmp ("-v", argv[i]) == 0)
+        {
+            // Set up the Log level for OpenMAMA internals
+            mama_setLogLevel(MAMA_LOG_LEVEL_FINEST);
+        }
+        else if ((strcmp (argv[i], "-h") == 0)||
+                 (strcmp (argv[i], "--help") == 0)||
+                 (strcmp (argv[i], "-?") == 0))
+        {
+            usageAndExit(argv[0]);
+        }
+        else
+        {
+            fprintf(stderr, "Unknown arg: %s\n",    argv[i]);
+            usageAndExit(argv[0]);
+        }
+        ++i;
     }
 
     try {


### PR DESCRIPTION
These changes include:

- Added OpenMAMA Config and target options for modern Cmake use
  (this should now make OpenMAMA work with vanilla find_package)
- Cmake minimum version required is now 3.16
- Updated tutorials to not use getopt to work natively on windows
- Fixed windows issue with some headers being missing from install
- Fixed Ubuntu 18 build to use more recent ruby so FPM would work
- Added aprutil to dependencies for vcpkg and apt / yum