### PR TITLE
COMMON: Bump OWASP dependency-check to 12.1.0

### DIFF
--- a/mama/jni/build.gradle
+++ b/mama/jni/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:8.4.3'
+        classpath 'org.owasp:dependency-check-gradle:12.1.0'
     }
 }
 
@@ -12,7 +12,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'com.adarshr.test-logger' version '4.0.0'
-    id 'org.owasp.dependencycheck' version "8.4.3"
+    id 'org.owasp.dependencycheck' version "12.1.0"
 }
 
 dependencyCheck {

--- a/mamda/java/build.gradle
+++ b/mamda/java/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.owasp:dependency-check-gradle:8.4.3'
+        classpath 'org.owasp:dependency-check-gradle:12.1.0'
     }
 }
 
@@ -12,7 +12,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'com.adarshr.test-logger' version '4.0.0'
-    id 'org.owasp.dependencycheck' version "8.4.3"
+    id 'org.owasp.dependencycheck' version "12.1.0"
 }
 
 dependencyCheck {


### PR DESCRIPTION
Updated version of org.owasp.dependencycheck from 8.4.3 to 12.1.0