### PR TITLE
Update badge and link path to reflect changes to the FINOS project lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build CI](https://img.shields.io/github/actions/workflow/status/finos/OpenMAMA/main.yml?label=Build%20CI)](https://github.com/finos/openmama/actions/workflows/main.yml)
-[![FINOS - Active](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-active.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Active)
+[![FINOS - Graduated](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-graduated.svg)](https://community.finos.org/docs/governance/lifecycle-stages/graduated)
 [![License](https://img.shields.io/badge/License-LGPLv2.1-blue.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/6741/badge)](https://bestpractices.coreinfrastructure.org/projects/6741) 
 [![Join the chat at https://gitter.im/OpenMAMA/OpenMAMA](https://badges.gitter.im/OpenMAMA/OpenMAMA.svg)](https://gitter.im/OpenMAMA/OpenMAMA?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -58,4 +58,3 @@ depends on several third party libraries, the licenses for which are listed in t
 Contributing
 --------------------------------------------------------------------------------
 Information on contributing on the project can be found [here](https://openmama.finos.org/openmama_submission_process.html).
-


### PR DESCRIPTION
This PR changes the active badge to the graduated badge and updates the badge link path to `/lifecycle-stages/` to reflect the new documentation structure on https://community.finos.org/docs/governance/.

The `active` stage has been renamed to `graduated` per the new FINOS project lifecycle. Please make sure to read and understand the new [FINOS project lifecycle](https://www.finos.org/blog/updated-finos-project-lifecycle) and reach out to toc@lists.finos.org if you have any questions regarding the new lifecycle.

> [!IMPORTANT]
> This PR was generated automatically. We kindly ask you to review it manually, confirm there are no other occurrences of the badge logic in other files, and merge at your earliest convenience. If you have any questions or concerns, please email help@finos.org.